### PR TITLE
fix pythonw and pyinstaller 5.7 logger recursion error

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -614,6 +614,11 @@ def add_kivy_handlers(logger):
 KIVY_LOG_MODE = os.environ.get("KIVY_LOG_MODE", "KIVY")
 assert KIVY_LOG_MODE in ("KIVY", "PYTHON", "MIXED"), "Unknown log mode"
 
+# if run from pythonw or pyinstaller v5.7, sys.stderr is None
+# If sys.stderr is None the ConsoleHandler() must not be loaded
+if sys.stderr is None:
+    os.environ['KIVY_NO_CONSOLELOG'] = '1'
+
 if KIVY_LOG_MODE == "KIVY":
     # Add the Kivy handlers to the root logger, so they will be used
     # for all propagated log messages.


### PR DESCRIPTION
Kivy apps will crash if run from pythonw or if they are built with pyinstaller 5.7 without explicitly turning off the console log.  Pythonw and Pyinstaller 5.7 set sys.stderr to None,  if the console log is not turned off, a recursion error in the python logger occurs.  

This fix sets the KIVY_NO_CONSOLELOG environment if sys.stderr is None.  This preserves the behavior prior to pyinstaller 5.7, and allows correct operation under pythonw.exe

This will fix this issue: https://github.com/kivy/kivy/issues/8074

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
