### PR TITLE
[build wheel ios] Build KivyThorVG.xcframework for iOS wheels

### DIFF
--- a/PHASE_2_IOS_DESIGN.md
+++ b/PHASE_2_IOS_DESIGN.md
@@ -1,0 +1,411 @@
+# Phase 2 — iOS ThorVG XCFramework
+
+Personal design note. Not for circulation. Captures the iOS plan after
+Phase 1 desktop is done.
+
+> **Reading this on the Mac**: this file is in the Windows `KivyPRs/`
+> workspace and won't transfer with a fresh clone. Either copy via
+> cloud / USB, or just re-read it from the Cursor chat history (it's
+> rendered inline in the conversation that made it).
+
+---
+
+## 1. State of the world (entering Phase 2)
+
+### Phase 1 — done, all four PRs green
+| PR | Branch | Status |
+|---|---|---|
+| #9297 | `feature/thorvg-cython` | green, merge first |
+| #9273 | `feature/svg-image-provider` | green, rebased on #9297 |
+| #9284 | `feature/svg-widget` | green, rebased on #9297 |
+| #9293 | `feature/lottie-provider` | green, rebased on #9297 |
+
+Maintainer (`@misl6`) has confirmed merge order.
+
+### Phase 1 → Phase 2 contract
+Phase 1 deliberately produced two reusable pieces specifically for
+Phase 2:
+
+1. **`tools/build_thorvg.sh`** — Meson build script with a
+   `THORVG_SHARED=1` knob, universal-arch handling, and bundled
+   PNG / JPG codecs via `-Dstatic=true`. Already proven to produce
+   `libthorvg-1.dylib` on macOS universal2.
+2. **`tools/macos_framework_wrapper.sh`** — wraps a Mach-O dylib into a
+   non-versioned `.framework` bundle. Already built with iOS reuse
+   in mind: accepts `FRAMEWORK_MIN_OS_VERSION` env var and rewrites
+   `LC_ID_DYLIB` to `@rpath/<Name>.framework/<Name>`.
+
+Phase 2's job is to wire these two into Kivy's existing iOS pipeline.
+
+### What's already in `kivy/kivy` (we don't have to build it)
+Read these to understand the existing iOS pipeline before extending:
+
+- `tools/build_ios_dependencies.sh` — single canonical iOS dep
+  builder, runs once before cibuildwheel. Builds SDL3 / SDL3_image /
+  SDL3_mixer / SDL3_ttf and unpacks ANGLE. Each output is an
+  **`.xcframework`** under `ios-kivy-dependencies/dist/Frameworks/`.
+- `.github/workflows/ios_wheels.yml` — gated on `[build wheel]` /
+  `[build wheel ios]` / tag / schedule. Builds three slices via
+  cibuildwheel (`CIBW_ARCHS: "arm64_iphoneos arm64_iphonesimulator x86_64_iphonesimulator"`).
+  Cache key is `hashFiles('tools/build_ios_dependencies.sh')` — adding
+  ThorVG to that script automatically invalidates the cache exactly
+  once.
+- `tools/add-ios-frameworks.py` — runs **after** cibuildwheel.
+  Auto-discovers every `*.xcframework` under
+  `$KIVY_DEPS_ROOT/dist/Frameworks/` and packs each into the wheel
+  under `.frameworks/`. **No allowlist update needed** — once we
+  produce `KivyThorVG.xcframework` in that directory, it's picked up
+  for free.
+- `setup.py` lines 201–269 — `plat_options['ios']['frameworks']` dict.
+  Each entry points at the per-slice `.framework` directly under the
+  xcframework via the `plat_arch` key
+  (`ios-arm64` for device, `ios-arm64_x86_64-simulator` for sim). This is
+  what `setup.py` actually links against during cibuildwheel.
+
+### Pattern to copy: SDL3
+SDL3 is the closest analogue (it's a real C lib, not a CMake-based
+download like ANGLE). Its `tools/build_ios_dependencies.sh` block is:
+
+```bash
+for platform in "iOS" "iOS Simulator"; do
+  platform_arg=$([ "$platform" = "iOS" ] && echo "iphoneos" || echo "iphonesimulator")
+  xcodebuild archive -scheme SDL3 ... -destination "generic/platform=$platform" ...
+done
+xcodebuild -create-xcframework \
+  -framework Xcode/SDL/build/Release-iphoneos.xcarchive/Products/Library/Frameworks/SDL3.framework \
+  -framework Xcode/SDL/build/Release-iphonesimulator.xcarchive/Products/Library/Frameworks/SDL3.framework \
+  -output ../../dist/Frameworks/SDL3.xcframework
+```
+
+Notes:
+- **Two slices in the xcframework**, not three. iOS device
+  (`iphoneos`, arm64) + iOS Simulator (`iphonesimulator`,
+  arm64+x86_64 universal). cibuildwheel still expands to three
+  wheels because the simulator slice is universal but the wheel
+  ABI tags are per-arch.
+- SDL3 ships an Xcode project, so `xcodebuild` does it directly.
+  ThorVG only ships Meson, so we have to drive Meson manually with
+  per-platform SDK + `-arch` flags. Same shape, different tooling.
+
+---
+
+## 2. Phase 2 architecture
+
+### Deliverable layout
+```
+ios-kivy-dependencies/dist/Frameworks/
+├── SDL3.xcframework/         (existing, unchanged)
+├── SDL3_image.xcframework/   (existing, unchanged)
+├── SDL3_mixer.xcframework/   (existing, unchanged)
+├── SDL3_ttf.xcframework/     (existing, unchanged)
+├── libEGL.xcframework/       (existing, unchanged — from ANGLE)
+├── libGLESv2.xcframework/    (existing, unchanged — from ANGLE)
+└── KivyThorVG.xcframework/   (new)
+    ├── ios-arm64/
+    │   └── KivyThorVG.framework/
+    │       ├── KivyThorVG     (libthorvg-1.dylib renamed, LC_ID_DYLIB rewritten)
+    │       ├── Headers/       (thorvg_capi.h)
+    │       └── Info.plist
+    └── ios-arm64_x86_64-simulator/
+        └── KivyThorVG.framework/
+            ├── KivyThorVG     (universal libthorvg-1.dylib for sim)
+            ├── Headers/
+            └── Info.plist
+```
+
+### Build pipeline (extension to `tools/build_ios_dependencies.sh`)
+
+```bash
+# After SDL3_ttf block — add this:
+echo "-- Build ThorVG (universal iOS XCFramework)"
+
+# Per-slice build via existing tools/build_thorvg.sh
+# (drives Meson with -arch flags + iOS SDK paths via THORVG_IOS env)
+for slice in iphoneos iphonesimulator; do
+  THORVG_IOS=$slice \
+  THORVG_SHARED=1 \
+  THORVG_INSTALL_PREFIX="$(pwd)/../dist/thorvg-$slice" \
+  bash $REPO/tools/build_thorvg.sh
+
+  bash $REPO/tools/macos_framework_wrapper.sh \
+    --dylib "$(pwd)/../dist/thorvg-$slice/lib/libthorvg-1.1.dylib" \
+    --name KivyThorVG \
+    --output-dir "$(pwd)/../dist/thorvg-$slice/Frameworks" \
+    --headers "$(pwd)/../dist/thorvg-$slice/include/thorvg-1"
+  # FRAMEWORK_MIN_OS_VERSION=14.0 already supported by the wrapper
+done
+
+xcodebuild -create-xcframework \
+  -framework "$(pwd)/../dist/thorvg-iphoneos/Frameworks/KivyThorVG.framework" \
+  -framework "$(pwd)/../dist/thorvg-iphonesimulator/Frameworks/KivyThorVG.framework" \
+  -output ../../dist/Frameworks/KivyThorVG.xcframework
+```
+
+### Meson cross-file approach (in `tools/build_thorvg.sh`)
+
+ThorVG's universal2 macOS path passes `-arch x86_64 -arch arm64`
+directly to Apple Clang via `-Dc_args` / `-Dcpp_args`. iOS needs the
+same idea plus the right SDK and deployment target:
+
+| Slice | `-arch` | SDK | Deployment target |
+|---|---|---|---|
+| `iphoneos` | `arm64` | `iphoneos` (`xcrun --sdk iphoneos --show-sdk-path`) | `-mios-version-min=14.0` |
+| `iphonesimulator` | `arm64 x86_64` | `iphonesimulator` | `-mios-simulator-version-min=14.0` |
+
+Meson invocation per slice (rough):
+
+```bash
+SDK_PATH=$(xcrun --sdk $THORVG_IOS --show-sdk-path)
+ARCHS=$([ "$THORVG_IOS" = "iphoneos" ] && echo "-arch arm64" || echo "-arch arm64 -arch x86_64")
+MINVER=$([ "$THORVG_IOS" = "iphoneos" ] \
+  && echo "-mios-version-min=14.0" \
+  || echo "-mios-simulator-version-min=14.0")
+
+meson setup build-$THORVG_IOS \
+  --cross-file <(generate_ios_cross_file) \
+  --buildtype=release --default-library=shared \
+  --prefix="$THORVG_INSTALL_PREFIX" --libdir=lib \
+  -Dlog=false -Dstatic=true -Dthreads=false \
+  -Dtests=false -Dbindings=capi \
+  -Dloaders=svg,lottie,png,jpg,ttf -Dengines=cpu -Dextra= \
+  -Dc_args="-isysroot $SDK_PATH $ARCHS $MINVER" \
+  -Dcpp_args="-isysroot $SDK_PATH $ARCHS $MINVER" \
+  -Dc_link_args="-isysroot $SDK_PATH $ARCHS $MINVER" \
+  -Dcpp_link_args="-isysroot $SDK_PATH $ARCHS $MINVER -lc++"
+```
+
+The cross-file is needed because iOS is a different host than the
+build machine; without it Meson assumes macOS conventions and the
+SDK path won't bind to the right libc++ headers / sysroot.
+
+**Decision point** for the cross-file: ThorVG upstream doesn't ship
+any. Two options:
+
+- **2A**: Generate the cross-file inline in `tools/build_thorvg.sh`
+  via heredoc (single source of truth, no extra files).
+- **2B**: Add a static `tools/meson-cross-ios-{device,sim}.ini` pair.
+  Cleaner, but adds two files. Probably better long-term.
+
+Lean toward **2B**. Two-file overhead is small and Meson cross-files
+are way easier to read as standalone INI than embedded heredoc.
+
+### `setup.py` extension
+
+Mirror SDL3 in `plat_options['ios']`:
+
+```python
+thorvg_xc = join(KIVY_DEPS_ROOT, 'dist', 'Frameworks', 'KivyThorVG.xcframework')
+thorvg_fw = join(thorvg_xc, plat_arch, 'KivyThorVG.framework')
+thorvg_headers = join(thorvg_fw, 'Headers')
+
+ios_data['frameworks']['KivyThorVG'] = {
+    'path': thorvg_fw,
+    'headers': thorvg_headers,
+    'xc': thorvg_xc,
+}
+```
+
+Then in `determine_thorvg_flags()`, add an `ios` branch that mirrors
+the existing `darwin + use_osx_frameworks` branch:
+
+```python
+if platform == 'ios':
+    ios_frameworks = plat_options['ios']['frameworks']
+    thorvg_fw = ios_frameworks['KivyThorVG']
+    return {
+        'include_dirs': [thorvg_fw['headers']],
+        'extra_link_args': [
+            '-F', dirname(thorvg_fw['path']),
+            '-framework', 'KivyThorVG',
+            '-Wl,-rpath,@executable_path/Frameworks',
+        ],
+        'libraries': [],
+        'define_macros': [],
+    }
+```
+
+No `TVG_STATIC` — same as macOS desktop. The `@executable_path/Frameworks`
+rpath matches what Kivy's iOS bundle layout uses (look at how SDL3 does
+it; should be identical).
+
+**Important**: `setup.py:971` currently bundles `'ios'` in with
+`('win32', 'android', 'ios')` as a "static linking" platform.
+That branch needs to keep `'win32'` and `'android'` but remove
+`'ios'` once the framework path lands. **Verify before changing**:
+read the surrounding `_thorvg.pyx` extension block to confirm there
+isn't another `'ios'` static-only path I'm missing.
+
+### `tools/add-ios-frameworks.py`
+**No change.** Auto-discovery picks up `KivyThorVG.xcframework` from
+`$KIVY_DEPS_ROOT/dist/Frameworks/` once it exists.
+
+---
+
+## 3. Implementation order
+
+Single PR, single branch (`feature/thorvg-ios-wheel`). Six commits,
+in this order. Every commit should leave the tree green for desktop —
+iOS CI is gated on `[build wheel ios]` so it only runs when we ask.
+
+1. **Add iOS cross-files** — `tools/meson-cross-ios-{device,sim}.ini`.
+   Standalone, no integration. Sanity check: `meson setup --cross-file`
+   succeeds on a hello-world meson project.
+2. **Extend `tools/build_thorvg.sh` with `THORVG_IOS` mode** — when
+   set, picks the right cross-file, SDK, archs, min-version flags.
+   Other code paths (Linux shared, macOS universal2, Windows static)
+   unchanged. **Sanity check on the Mac**: run
+   `THORVG_IOS=iphoneos THORVG_SHARED=1 ./tools/build_thorvg.sh`
+   manually, `lipo -info` the output dylib, `otool -L` to verify
+   `LC_ID_DYLIB` and rpath.
+3. **Extend `tools/build_ios_dependencies.sh` with the ThorVG block**
+   — per-slice Meson build, framework wrap, xcframework merge.
+   **Sanity check**: run the whole script clean
+   (`rm -rf ios-kivy-dependencies && ./tools/build_ios_dependencies.sh`),
+   inspect the produced `KivyThorVG.xcframework`, run
+   `xcrun xcodebuild -checkFirstLaunchStatus` on it (or
+   `plutil -p */Info.plist`).
+4. **Extend `setup.py::plat_options['ios']` and `determine_thorvg_flags()`**
+   — wire the framework into the iOS link line. Verify
+   `setup.py:971` static-platform list updated correctly.
+5. **Local `cibuildwheel` for one slice** — run
+   `CIBW_PLATFORM=ios CIBW_ARCHS=arm64_iphoneos python -m cibuildwheel`,
+   inspect the produced wheel:
+   - `unzip -l <wheel>` — `.frameworks/KivyThorVG.xcframework/...`
+     present?
+   - `unzip -p <wheel> kivy/lib/thorvg/_thorvg*.so | otool -L -` —
+     `@rpath/KivyThorVG.framework/KivyThorVG` resolves?
+   - Run `add-ios-frameworks.py` on it manually if cibuildwheel
+     doesn't run that step locally.
+6. **Push `[build wheel ios]` commit** — let CI build all three
+   slices, download all three wheels, repeat the same inspection.
+   When green, open PR.
+
+---
+
+## 4. Open questions to resolve on the Mac
+
+These are deliberate gaps. Resolve when you have your hands on the
+actual artifact, not from the spec.
+
+### Q1. iOS deployment target
+Kivy probably has a canonical minimum iOS version. **Find it before
+choosing**. Check:
+- `tools/build_ios_dependencies.sh` (xcodebuild invocations may
+  inherit it from the upstream Xcode project — check
+  `IPHONEOS_DEPLOYMENT_TARGET` overrides),
+- any `.xcconfig` files in the kivy tree,
+- `cibuildwheel` defaults for iOS (it has its own minimum).
+
+If you can't find a canonical answer, **iOS 14.0** is a safe pick —
+matches CPython 3.13's iOS Tier 3 floor. Don't pick higher than
+whatever SDL3 / ANGLE were built with, or our framework will have a
+higher minimum than the rest of the iOS Kivy bundle and refuse to
+load on older devices.
+
+### Q2. Bitcode
+Apple deprecated bitcode in Xcode 14. ThorVG's Meson build doesn't
+emit bitcode by default. Verify SDL3 / ANGLE in the same wheel are
+also bitcode-free; if everyone agrees, no flags needed. If anyone
+emits it, we'll have to either match or strip. Likely a non-issue
+in 2026 Xcode.
+
+### Q3. Framework signing
+Frameworks bundled into a Python wheel aren't signed; the embedding
+app signs everything at app-bundle time (`codesign --deep` /
+`codesign --force` on the bundle's `Frameworks/` directory). Verify
+this works with our framework structure by checking that SDL3.xcframework
+has the same layout (Mach-O at top of `Foo.framework/`, no
+`Foo.framework/Versions/A/`) — that's why `macos_framework_wrapper.sh`
+emits non-versioned frameworks (the macOS desktop comment in
+that file explains).
+
+### Q4. Threads option (`-Dthreads=false`)
+We currently disable ThorVG's internal task scheduler on all
+platforms because the Cython wrapper calls
+`tvg_engine_init(SW, threads=0)`. iOS would benefit from threading
+on multi-core devices but the default is fine for parity with
+desktop wheels — iOS already pays a Python GIL tax that dwarfs the
+single-core ThorVG cost. **Defer turning threads back on** until
+someone profiles a real iOS Lottie scene and proves it matters.
+
+### Q5. xcframework slice naming
+Apple's xcframework naming convention is finicky. The slice
+directory inside the xcframework must be named exactly
+`ios-arm64` for device and `ios-arm64_x86_64-simulator` for the
+universal simulator slice. `xcodebuild -create-xcframework`
+generates these names automatically from the platform/architecture
+of each input framework — but verify by `ls` on the produced
+xcframework and confirm those exact names match
+`plat_options['ios']['platform_arch']` (setup.py line 206).
+If they differ, setup.py won't find the per-slice .framework and
+the build will fail with a missing-framework error.
+
+---
+
+## 5. Validation checklist (before opening PR)
+
+Run all of these locally on the Mac (Intel) **before** pushing
+`[build wheel ios]`:
+
+- [ ] `tools/build_thorvg.sh` (no env vars) — desktop universal2
+      build still produces `libthorvg-1.dylib`, `lipo -info` shows
+      both arches. Regression guard.
+- [ ] `THORVG_IOS=iphoneos tools/build_thorvg.sh` — produces
+      arm64-only `libthorvg-1.dylib`, `otool -hv` shows
+      `IPHONEOS_VERSION_MIN` matches Q1's chosen target.
+- [ ] `THORVG_IOS=iphonesimulator tools/build_thorvg.sh` — produces
+      universal arm64+x86_64 dylib, `IPHONEOS_SIMULATOR_VERSION_MIN`
+      set.
+- [ ] `tools/build_ios_dependencies.sh` end-to-end clean run.
+      Cache invalidates correctly (delete `ios-kivy-dependencies/`
+      first).
+- [ ] `find ios-kivy-dependencies/dist/Frameworks/KivyThorVG.xcframework`
+      shows the two expected slice dirs.
+- [ ] `cibuildwheel` for `arm64_iphoneos` produces a wheel; unpack
+      it; `_thorvg*.so | otool -L` shows `@rpath/KivyThorVG.framework/KivyThorVG`.
+- [ ] Run `python ./tools/add-ios-frameworks.py wheelhouse/`;
+      re-unzip the wheel; `.frameworks/KivyThorVG.xcframework/`
+      present.
+- [ ] Optional but valuable: install the wheel into a local Briefcase
+      / Toga iOS app, build for simulator, run and import
+      `kivy.lib.thorvg`. Catches anything CI misses.
+
+---
+
+## 6. PR submission
+
+- Branch: `feature/thorvg-ios-wheel` (off `master`, NOT off
+  `feature/thorvg-cython` — by the time we open this, #9297 will
+  have merged).
+- Title: `Build KivyThorVG.xcframework for iOS wheels`
+- Body: Stack-link to the four merged STAGE 1 PRs. Note that this
+  PR does **not** require any Phase 1 changes (#9297 etc. must
+  already be on master so the Cython wrapper exists to be linked
+  against).
+- Reviewers: `@misl6` for the iOS pipeline shape, `@psychowasp`
+  for the SVG/Lottie consumer perspective, `@T-Dynamos` cc'd to
+  signal that Android comes next.
+- CI gate: include `[build wheel ios]` in the first commit message
+  so the iOS wheel job runs without waiting for a tag.
+
+---
+
+## 7. Out of scope (Phase 3 candidates)
+
+- **Android**: blocked on `@T-Dynamos` guidance. Open questions:
+  output format (.so collection vs `.aar`?), ABI list (`arm64-v8a`,
+  `armeabi-v7a`, `x86_64`?), NDK pin, API level. Deliberately not
+  speculating until the maintainer weighs in.
+- **iOS threading**: see Q4.
+- **Framework signing automation**: see Q3.
+- **CI cache eviction**: ThorVG version bumps will need to update
+  the `tools/build_ios_dependencies.sh` cache key. That's already
+  the case (it uses `hashFiles('tools/build_ios_dependencies.sh')`),
+  so the version bump in `tools/build_thorvg.sh` may not invalidate
+  by itself — consider also hashing `tools/build_thorvg.sh` in the
+  cache key on the iOS workflow. Not required for the initial PR
+  but worth noting.
+
+---
+
+*Created during STAGE 1 close-out, 2026-04-24.*

--- a/kivy/lib/thorvg/__init__.py
+++ b/kivy/lib/thorvg/__init__.py
@@ -1,0 +1,49 @@
+"""
+:mod:`kivy.lib.thorvg`
+======================
+
+Minimal, internal Python binding to the ThorVG v1.0.4 C API, used by Kivy's
+SVG, SVG-image and Lottie providers.
+
+This is **not** a general-purpose Python binding for ThorVG: it exposes only
+the subset of ``thorvg_capi.h`` needed by :mod:`kivy.core.svg`,
+:mod:`kivy.core.image.img_thorvg_svg` and :mod:`kivy.core.lottie`.
+Applications that want the full ThorVG surface should use
+`thorvg-python <https://github.com/thorvg/thorvg-python>`_ (top-level
+``import thorvg``); it coexists peacefully with this package because the
+import paths do not overlap.
+
+This module is a thin Cython wrapper around ``thorvg_capi.h`` - see
+:mod:`kivy.lib.thorvg._thorvg` for the actual binding and
+:doc:`../../guide/lottie-svg` for consumer-facing docs.
+
+The ThorVG engine is initialised exactly once, the first time this package
+is imported. No explicit ``term()`` is required - OS process teardown handles
+that.
+
+.. note::
+
+    This package is an internal implementation detail of Kivy and its
+    public surface is limited to what the built-in SVG / Lottie providers
+    need. Users should not rely on the exact shape of this API.
+"""
+
+from kivy.lib.thorvg._thorvg import (  # noqa: F401
+    Result,
+    Paint,
+    Picture,
+    SwCanvas,
+    Accessor,
+    LottieAnimation,
+    engine_version,
+)
+
+__all__ = (
+    'Result',
+    'Paint',
+    'Picture',
+    'SwCanvas',
+    'Accessor',
+    'LottieAnimation',
+    'engine_version',
+)

--- a/kivy/lib/thorvg/_thorvg.pyx
+++ b/kivy/lib/thorvg/_thorvg.pyx
@@ -1,0 +1,741 @@
+# cython: language_level=3
+# distutils: language = c++
+"""
+Cython wrapper around the minimal ThorVG v1.0.4 C API used by Kivy's SVG,
+SVG-image and Lottie providers.
+
+Public surface (imported through [kivy/lib/thorvg/__init__.py](__init__.py)):
+
+- :class:`SwCanvas` - software raster canvas exposing its pixel buffer via
+  the Python buffer protocol for zero-copy texture uploads.
+- :class:`Picture` - SVG/Lottie/image paint node.
+- :class:`LottieAnimation` - Lottie animation wrapper that owns an internal
+  :class:`Picture`.
+- :class:`Accessor` - scene-tree walker + ID generator.
+- :class:`Paint` - base paint handle returned by :meth:`Picture.get_paint`
+  and inside :class:`Accessor` callbacks.
+- :class:`Result` - enum mirroring ``Tvg_Result`` values.
+
+Engine lifecycle:
+
+The ThorVG rendering engine is initialised exactly once when this module is
+first imported (``tvg_engine_init(threads=0)``). ThorVG's C API maintains an
+internal reference count for repeated ``init``/``term`` calls, so no Python
+shadow-refcounting is needed. The engine is not explicitly terminated - OS
+process teardown handles that cleanly.
+"""
+
+from cpython.buffer cimport PyBuffer_FillInfo
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from libc.stdint cimport uint8_t, uint32_t
+from libc.string cimport memset
+from libcpp cimport bool as cbool
+
+from enum import IntEnum
+
+from kivy.lib.thorvg cimport thorvg as tvg
+
+
+# ---------------------------------------------------------------------------
+# Result enum (mirrors Tvg_Result values)
+# ---------------------------------------------------------------------------
+
+
+class Result(IntEnum):
+    SUCCESS = <int>tvg.TVG_RESULT_SUCCESS
+    INVALID_ARGUMENT = <int>tvg.TVG_RESULT_INVALID_ARGUMENT
+    INSUFFICIENT_CONDITION = <int>tvg.TVG_RESULT_INSUFFICIENT_CONDITION
+    FAILED_ALLOCATION = <int>tvg.TVG_RESULT_FAILED_ALLOCATION
+    MEMORY_CORRUPTION = <int>tvg.TVG_RESULT_MEMORY_CORRUPTION
+    NOT_SUPPORTED = <int>tvg.TVG_RESULT_NOT_SUPPORTED
+    UNKNOWN = <int>tvg.TVG_RESULT_UNKNOWN
+
+
+cdef inline object _wrap_result(tvg.Tvg_Result r):
+    # Unknown future values pass through as-is rather than raising.
+    try:
+        return Result(<int>r)
+    except ValueError:
+        return <int>r
+
+
+# ---------------------------------------------------------------------------
+# Engine bootstrap (runs once at module import)
+# ---------------------------------------------------------------------------
+
+
+cdef tvg.Tvg_Result _engine_init_result = tvg.tvg_engine_init(0)
+if _engine_init_result != tvg.TVG_RESULT_SUCCESS:
+    # Engine init failure is non-recoverable for the wrapper - surface it
+    # immediately at import time.
+    raise RuntimeError(
+        'kivy.lib.thorvg: tvg_engine_init failed with result {}'.format(
+            <int>_engine_init_result))
+
+
+def engine_version():
+    """Return the ThorVG engine version as a ``(result, major, minor, micro,
+    version_string)`` tuple.
+    """
+    cdef uint32_t major = 0
+    cdef uint32_t minor = 0
+    cdef uint32_t micro = 0
+    cdef const char *version = NULL
+    cdef tvg.Tvg_Result r = tvg.tvg_engine_version(
+        &major, &minor, &micro, &version)
+    py_version = version.decode('utf-8') if version is not NULL else None
+    return (_wrap_result(r), <int>major, <int>minor, <int>micro, py_version)
+
+
+# ---------------------------------------------------------------------------
+# Paint (base class - also used to wrap non-owned handles from Picture /
+# Accessor callbacks).
+# ---------------------------------------------------------------------------
+
+
+cdef class Paint:
+    """A thin wrapper around a ``Tvg_Paint`` handle.
+
+    ``_owned`` tracks whether Python is responsible for unref'ing the paint
+    on ``__dealloc__``:
+
+    - ``True`` when the paint was created by user code (e.g. ``Picture()``)
+      and has not yet been handed off to a :class:`SwCanvas`.
+    - ``False`` for paints fetched via :meth:`Picture.get_paint`, paints
+      exposed through :meth:`Accessor` callbacks, or any paint whose
+      ownership has been transferred to a canvas via :meth:`SwCanvas.add`.
+    """
+
+    cdef tvg.Tvg_Paint _paint
+    cdef bint _owned
+
+    def __cinit__(self):
+        self._paint = NULL
+        self._owned = False
+
+    def __dealloc__(self):
+        if self._paint != NULL and self._owned:
+            tvg.tvg_paint_unref(self._paint, True)
+            self._paint = NULL
+
+    @staticmethod
+    cdef Paint _wrap(tvg.Tvg_Paint handle, bint owned):
+        cdef Paint p = Paint.__new__(Paint)
+        p._paint = handle
+        p._owned = owned
+        return p
+
+    def set_opacity(self, int opacity):
+        """Set the paint opacity (0-255). Returns a :class:`Result`."""
+        if self._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef uint8_t op
+        if opacity < 0:
+            op = 0
+        elif opacity > 255:
+            op = 255
+        else:
+            op = <uint8_t>opacity
+        return _wrap_result(tvg.tvg_paint_set_opacity(self._paint, op))
+
+    def get_id(self):
+        """Return the paint's internal ID hash, or 0 if unset."""
+        if self._paint == NULL:
+            return 0
+        return <unsigned long>tvg.tvg_paint_get_id(self._paint)
+
+
+# ---------------------------------------------------------------------------
+# Picture (SVG / Lottie / raster picture loader)
+# ---------------------------------------------------------------------------
+
+
+cdef class Picture(Paint):
+    """A ``Picture`` paint node.
+
+    Can be constructed directly and loaded via :meth:`load` / :meth:`load_data`,
+    or obtained from :meth:`LottieAnimation.get_picture` in which case the
+    picture is owned by the animation and must not be unref'd here.
+    """
+
+    def __cinit__(self, *args, **kwargs):
+        self._paint = tvg.tvg_picture_new()
+        self._owned = True
+
+    def load(self, path):
+        """Load a picture from *path* (file). Returns a :class:`Result`."""
+        if self._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        if isinstance(path, str):
+            path_bytes = path.encode('utf-8')
+        else:
+            path_bytes = bytes(path)
+        cdef bytes _b = path_bytes
+        cdef const char *p = _b
+        return _wrap_result(tvg.tvg_picture_load(self._paint, p))
+
+    def load_data(self, data, mimetype='', rpath=None, copy=True):
+        """Load a picture from in-memory *data* bytes.
+
+        :param bytes data: Raw file contents.
+        :param str mimetype: e.g. ``'svg'``, ``'lottie'``.
+        :param rpath: Optional resource path string for external references.
+        :param bool copy: If ``True``, ThorVG copies *data* into its own
+            buffer. If ``False``, the caller must keep *data* alive for the
+            lifetime of the picture.
+        """
+        if self._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        if not isinstance(data, (bytes, bytearray)):
+            if isinstance(data, str):
+                data = data.encode('utf-8')
+            else:
+                data = bytes(data)
+        cdef bytes _data = bytes(data)
+        cdef const char *data_ptr = _data
+        cdef uint32_t data_len = <uint32_t>len(_data)
+
+        if isinstance(mimetype, str):
+            mt_bytes = mimetype.encode('utf-8')
+        else:
+            mt_bytes = bytes(mimetype)
+        cdef bytes _mt = mt_bytes
+        cdef const char *mt_ptr = _mt
+
+        cdef bytes _rp
+        cdef const char *rp_ptr = NULL
+        if rpath is not None:
+            if isinstance(rpath, str):
+                _rp = rpath.encode('utf-8')
+            else:
+                _rp = bytes(rpath)
+            rp_ptr = _rp
+
+        cdef bint c_copy = <bint>bool(copy)
+        return _wrap_result(tvg.tvg_picture_load_data(
+            self._paint, data_ptr, data_len, mt_ptr, rp_ptr, c_copy))
+
+    def set_size(self, float w, float h):
+        """Resize the picture content. Returns a :class:`Result`."""
+        if self._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        return _wrap_result(tvg.tvg_picture_set_size(self._paint, w, h))
+
+    def get_size(self):
+        """Return ``(result, w, h)`` - the picture's intrinsic size."""
+        if self._paint == NULL:
+            return (Result.INVALID_ARGUMENT, 0.0, 0.0)
+        cdef float w = 0.0
+        cdef float h = 0.0
+        cdef tvg.Tvg_Result r = tvg.tvg_picture_get_size(
+            self._paint, &w, &h)
+        return (_wrap_result(r), float(w), float(h))
+
+    def get_paint(self, id):
+        """Look up a child paint by ID hash; return ``None`` if not found.
+
+        *id* is a ``uint32_t`` handle - typically obtained from
+        :meth:`Accessor.accessor_generate_id` or :meth:`Paint.get_id`.
+        The parameter is declared untyped so that Python ints in the full
+        ``uint32_t`` range (0..2^32 - 1) are accepted without Cython
+        raising ``OverflowError`` on values above ``INT_MAX``.
+
+        The returned :class:`Paint` is not owned by Python - it is a
+        non-owning view into the picture's scene tree.
+        """
+        if self._paint == NULL:
+            return None
+        cdef uint32_t c_id = <uint32_t><unsigned long>id
+        cdef tvg.Tvg_Paint child = <tvg.Tvg_Paint>tvg.tvg_picture_get_paint(
+            self._paint, c_id)
+        if child == NULL:
+            return None
+        return Paint._wrap(child, False)
+
+    def set_accessible(self, accessible):
+        """Enable or disable the accessible-mode ID→name map for SVGs.
+
+        Must be called before :meth:`load` / :meth:`load_data`. Required for
+        :meth:`Accessor.get_name` to resolve to the original SVG ``id``.
+        """
+        if self._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef bint c_acc = <bint>bool(accessible)
+        return _wrap_result(tvg.tvg_picture_set_accessible(
+            self._paint, c_acc))
+
+
+cdef Picture _wrap_borrowed_picture(tvg.Tvg_Paint handle):
+    """Wrap an externally-owned picture handle (e.g. from an animation).
+
+    ``Picture.__cinit__`` always allocates a fresh ``Tvg_Paint``; we
+    immediately free it and replace with *handle*, marking the wrapper as
+    non-owning so ``__dealloc__`` is a no-op.
+    """
+    cdef Picture p = Picture()
+    if p._paint != NULL:
+        tvg.tvg_paint_unref(p._paint, True)
+    p._paint = handle
+    p._owned = False
+    return p
+
+
+# ---------------------------------------------------------------------------
+# SwCanvas
+# ---------------------------------------------------------------------------
+
+
+cdef class SwCanvas:
+    """Software canvas backed by an RGBA pixel buffer.
+
+    The buffer is exposed via the Python buffer protocol as a 1-D ``bytes``
+    (``format='B'``) of length ``stride * h * 4``. ``bytes(canvas)`` copies
+    the buffer, while ``memoryview(canvas)`` / Kivy's
+    ``Texture.blit_buffer(canvas)`` access it without copying.
+
+    The buffer is valid for access only outside the ``draw()`` / ``sync()``
+    window - always call :meth:`sync` before reading pixels.
+    """
+
+    cdef tvg.Tvg_Canvas _canvas
+    cdef uint32_t *_buffer
+    cdef Py_ssize_t _buffer_len_bytes
+    cdef readonly int w
+    cdef readonly int h
+    cdef readonly int stride
+    # Keep strong refs to paints added through `add()` so that GC'ing the
+    # Python wrapper does not leave the canvas holding a freed handle (the
+    # canvas treats Paint ownership as transferred and will free them on
+    # destroy).
+    cdef list _paints
+
+    def __cinit__(self):
+        self._canvas = NULL
+        self._buffer = NULL
+        self._buffer_len_bytes = 0
+        self.w = 0
+        self.h = 0
+        self.stride = 0
+        self._paints = []
+
+    def __init__(self):
+        self._canvas = tvg.tvg_swcanvas_create(tvg.TVG_ENGINE_OPTION_DEFAULT)
+        if self._canvas == NULL:
+            raise RuntimeError(
+                'kivy.lib.thorvg: tvg_swcanvas_create returned NULL')
+
+    def __dealloc__(self):
+        # Canvas destruction frees the paints it owns; drop our Python-side
+        # list first so their __dealloc__ doesn't attempt to unref them.
+        for p in self._paints or []:
+            (<Paint>p)._owned = False
+        self._paints = None
+        if self._canvas != NULL:
+            tvg.tvg_canvas_destroy(self._canvas)
+            self._canvas = NULL
+        if self._buffer != NULL:
+            PyMem_Free(self._buffer)
+            self._buffer = NULL
+
+    def set_target(self, int w, int h, stride=None):
+        """Allocate/resize the RGBA pixel buffer and bind it to the canvas.
+
+        :param int w: width in pixels.
+        :param int h: height in pixels.
+        :param int stride: row stride in pixels. Defaults to *w*.
+        """
+        if self._canvas == NULL:
+            return Result.INVALID_ARGUMENT
+        if w <= 0 or h <= 0:
+            return Result.INVALID_ARGUMENT
+        cdef int c_stride = w if stride is None else int(stride)
+        if c_stride <= 0:
+            return Result.INVALID_ARGUMENT
+        cdef Py_ssize_t needed = <Py_ssize_t>c_stride * <Py_ssize_t>h \
+            * <Py_ssize_t>sizeof(uint32_t)
+        cdef uint32_t *buf
+        if self._buffer == NULL or self._buffer_len_bytes != needed:
+            if self._buffer != NULL:
+                PyMem_Free(self._buffer)
+                self._buffer = NULL
+                self._buffer_len_bytes = 0
+            buf = <uint32_t *>PyMem_Malloc(<size_t>needed)
+            if buf == NULL:
+                return Result.FAILED_ALLOCATION
+            self._buffer = buf
+            self._buffer_len_bytes = needed
+        memset(self._buffer, 0, <size_t>self._buffer_len_bytes)
+        cdef tvg.Tvg_Result r = tvg.tvg_swcanvas_set_target(
+            self._canvas, self._buffer,
+            <uint32_t>c_stride, <uint32_t>w, <uint32_t>h,
+            tvg.TVG_COLORSPACE_ABGR8888)
+        if r == tvg.TVG_RESULT_SUCCESS:
+            self.w = w
+            self.h = h
+            self.stride = c_stride
+        return _wrap_result(r)
+
+    def add(self, Paint paint not None):
+        """Add *paint* to the canvas. Ownership is transferred to the canvas.
+
+        After a successful ``add`` the Python :class:`Paint` wrapper becomes
+        non-owning; the paint will be freed when the canvas is destroyed (or
+        re-rendered with a different scene).
+        """
+        if self._canvas == NULL or paint._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef tvg.Tvg_Result r = tvg.tvg_canvas_add(
+            self._canvas, paint._paint)
+        if r == tvg.TVG_RESULT_SUCCESS:
+            paint._owned = False
+            self._paints.append(paint)
+        return _wrap_result(r)
+
+    def remove(self, Paint paint=None):
+        """Remove *paint* from the canvas, or clear all paints if ``None``."""
+        if self._canvas == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef tvg.Tvg_Paint p = NULL
+        if paint is not None:
+            p = paint._paint
+        cdef tvg.Tvg_Result r = tvg.tvg_canvas_remove(self._canvas, p)
+        if r == tvg.TVG_RESULT_SUCCESS:
+            if paint is None:
+                self._paints = []
+            else:
+                try:
+                    self._paints.remove(paint)
+                except ValueError:
+                    pass
+        return _wrap_result(r)
+
+    def update(self):
+        if self._canvas == NULL:
+            return Result.INVALID_ARGUMENT
+        return _wrap_result(tvg.tvg_canvas_update(self._canvas))
+
+    def draw(self, clear=True):
+        if self._canvas == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef bint c_clear = <bint>bool(clear)
+        return _wrap_result(tvg.tvg_canvas_draw(self._canvas, c_clear))
+
+    def sync(self):
+        if self._canvas == NULL:
+            return Result.INVALID_ARGUMENT
+        return _wrap_result(tvg.tvg_canvas_sync(self._canvas))
+
+    def destroy(self):
+        """Destroy the canvas and free its pixel buffer.
+
+        Subsequent operations return :class:`Result.INVALID_ARGUMENT`.
+        """
+        for p in self._paints or []:
+            (<Paint>p)._owned = False
+        self._paints = []
+        cdef tvg.Tvg_Result r = tvg.TVG_RESULT_SUCCESS
+        if self._canvas != NULL:
+            r = tvg.tvg_canvas_destroy(self._canvas)
+            self._canvas = NULL
+        if self._buffer != NULL:
+            PyMem_Free(self._buffer)
+            self._buffer = NULL
+            self._buffer_len_bytes = 0
+        self.w = 0
+        self.h = 0
+        self.stride = 0
+        return _wrap_result(r)
+
+    # -- Buffer protocol ---------------------------------------------------
+
+    def __getbuffer__(self, Py_buffer *view, int flags):
+        if self._buffer == NULL:
+            raise BufferError(
+                'SwCanvas buffer not allocated (call set_target first)')
+        PyBuffer_FillInfo(
+            view, self, <void *>self._buffer,
+            self._buffer_len_bytes, 0, flags)
+
+    def __releasebuffer__(self, Py_buffer *view):
+        pass
+
+    # -- Back-compat attribute expected by existing providers -------------
+
+    @property
+    def buffer_arr(self):
+        """Return ``self`` - a buffer-protocol object of raw RGBA bytes.
+
+        Keeps :func:`bytes(canvas.buffer_arr)` working for the existing
+        provider code that was written against ``thorvg-python``'s
+        ``SwCanvas.buffer_arr`` ctypes array attribute.
+        """
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Accessor
+# ---------------------------------------------------------------------------
+
+
+cdef cbool _accessor_trampoline(
+        tvg.Tvg_Paint paint, void *data) noexcept with gil:
+    """C callback passed to ``tvg_accessor_set``.
+
+    *data* is a pointer to a Python tuple ``(callback, user_data)`` held on
+    the Python ``Accessor`` instance for the duration of the call. We never
+    propagate Python exceptions back into ThorVG's traversal - errors are
+    caught here and reported via :mod:`kivy.logger`.
+    """
+    cdef object payload = <object>data
+    cdef Paint p = Paint._wrap(paint, False)
+    cdef object cb = payload[0]
+    cdef object user_data = payload[1]
+    try:
+        return bool(cb(p, user_data))
+    except Exception:
+        from kivy.logger import Logger
+        import traceback
+        Logger.error(
+            'ThorVG: accessor callback raised: {}'.format(
+                traceback.format_exc()))
+        return False
+
+
+cdef class Accessor:
+    """Scene-tree walker + ID generator.
+
+    Most usage involves :meth:`accessor_generate_id` (a pure hash function)
+    and :meth:`set` (walks a :class:`Picture` scene tree, invoking a Python
+    callback for each descendant paint).
+    """
+
+    cdef tvg.Tvg_Accessor _accessor
+    # Holds `(callback, user_data)` during a `set()` call so the C callback
+    # can dereference it safely.
+    cdef object _cb_payload
+
+    def __cinit__(self):
+        self._accessor = NULL
+        self._cb_payload = None
+
+    def __init__(self):
+        self._accessor = tvg.tvg_accessor_new()
+        if self._accessor == NULL:
+            raise RuntimeError(
+                'kivy.lib.thorvg: tvg_accessor_new returned NULL')
+
+    def __dealloc__(self):
+        if self._accessor != NULL:
+            tvg.tvg_accessor_del(self._accessor)
+            self._accessor = NULL
+
+    def accessor_generate_id(self, name):
+        """Hash *name* to the same 32-bit ID ThorVG uses for paint lookup."""
+        if isinstance(name, str):
+            name_bytes = name.encode('utf-8')
+        else:
+            name_bytes = bytes(name)
+        cdef bytes _n = name_bytes
+        cdef const char *np = _n
+        return <unsigned long>tvg.tvg_accessor_generate_id(np)
+
+    def get_name(self, id):
+        """Look up the original SVG ``id`` string for a given ID hash.
+
+        *id* accepts the full ``uint32_t`` range returned by
+        :meth:`accessor_generate_id` / :meth:`Paint.get_id`.  Only valid
+        inside an :meth:`set` callback for a :class:`Picture` loaded
+        with :meth:`Picture.set_accessible` ``True``.
+        """
+        if self._accessor == NULL:
+            return None
+        cdef uint32_t c_id = <uint32_t><unsigned long>id
+        cdef const char *s = tvg.tvg_accessor_get_name(
+            self._accessor, c_id)
+        if s is NULL:
+            return None
+        return s.decode('utf-8')
+
+    def set(self, Picture picture not None, func, data=b''):
+        """Walk *picture*'s scene tree, calling *func(paint, data)* for each.
+
+        *func* must return a truthy value to continue traversal, a falsy
+        value to stop. Exceptions raised inside the callback are logged and
+        terminate traversal.
+        """
+        if self._accessor == NULL or picture._paint == NULL:
+            return Result.INVALID_ARGUMENT
+        self._cb_payload = (func, data)
+        cdef tvg.Tvg_Result r
+        try:
+            r = tvg.tvg_accessor_set(
+                self._accessor, picture._paint,
+                _accessor_trampoline, <void *>self._cb_payload)
+        finally:
+            self._cb_payload = None
+        return _wrap_result(r)
+
+
+# ---------------------------------------------------------------------------
+# LottieAnimation
+# ---------------------------------------------------------------------------
+
+
+cdef class LottieAnimation:
+    """Lottie animation controller.
+
+    Constructing this class allocates an internal :class:`Picture` used to
+    load the Lottie JSON. Call :meth:`get_picture` to retrieve it, load the
+    file / bytes via the picture's :meth:`Picture.load` / :meth:`Picture.load_data`,
+    size it, add it to a :class:`SwCanvas`, then drive frames through this
+    animation object.
+    """
+
+    cdef tvg.Tvg_Animation _animation
+    cdef Picture _picture  # non-owning borrow; lifetime tied to animation.
+
+    def __cinit__(self):
+        self._animation = NULL
+        self._picture = None
+
+    def __init__(self):
+        self._animation = tvg.tvg_lottie_animation_new()
+        if self._animation == NULL:
+            raise RuntimeError(
+                'kivy.lib.thorvg: tvg_lottie_animation_new returned NULL')
+        cdef tvg.Tvg_Paint handle = tvg.tvg_animation_get_picture(
+            self._animation)
+        if handle == NULL:
+            tvg.tvg_animation_del(self._animation)
+            self._animation = NULL
+            raise RuntimeError(
+                'kivy.lib.thorvg: tvg_animation_get_picture returned NULL')
+        # The picture is owned by the animation; don't let Python free it.
+        self._picture = _wrap_borrowed_picture(handle)
+
+    def __dealloc__(self):
+        # Drop the picture wrapper first (non-owning, so this is a no-op on
+        # the C side), then delete the animation which frees both.
+        self._picture = None
+        if self._animation != NULL:
+            tvg.tvg_animation_del(self._animation)
+            self._animation = NULL
+
+    def get_picture(self):
+        """Return the :class:`Picture` owned by this animation."""
+        return self._picture
+
+    def set_frame(self, float frame):
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        return _wrap_result(tvg.tvg_animation_set_frame(
+            self._animation, frame))
+
+    def get_total_frame(self):
+        """Return ``(result, total_frames_float)``."""
+        if self._animation == NULL:
+            return (Result.INVALID_ARGUMENT, 0.0)
+        cdef float cnt = 0.0
+        cdef tvg.Tvg_Result r = tvg.tvg_animation_get_total_frame(
+            self._animation, &cnt)
+        return (_wrap_result(r), float(cnt))
+
+    def get_duration(self):
+        """Return ``(result, duration_seconds)``."""
+        if self._animation == NULL:
+            return (Result.INVALID_ARGUMENT, 0.0)
+        cdef float d = 0.0
+        cdef tvg.Tvg_Result r = tvg.tvg_animation_get_duration(
+            self._animation, &d)
+        return (_wrap_result(r), float(d))
+
+    def set_segment(self, float begin, float end):
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        return _wrap_result(tvg.tvg_animation_set_segment(
+            self._animation, begin, end))
+
+    def set_marker(self, name):
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        if isinstance(name, str):
+            b = name.encode('utf-8')
+        else:
+            b = bytes(name)
+        cdef bytes _b = b
+        cdef const char *p = _b
+        return _wrap_result(tvg.tvg_lottie_animation_set_marker(
+            self._animation, p))
+
+    def get_markers_cnt(self):
+        """Return ``(result, count)``."""
+        if self._animation == NULL:
+            return (Result.INVALID_ARGUMENT, 0)
+        cdef uint32_t cnt = 0
+        cdef tvg.Tvg_Result r = tvg.tvg_lottie_animation_get_markers_cnt(
+            self._animation, &cnt)
+        return (_wrap_result(r), <int>cnt)
+
+    def get_marker(self, int idx):
+        """Return ``(result, marker_name_or_None)`` for marker *idx*."""
+        if self._animation == NULL:
+            return (Result.INVALID_ARGUMENT, None)
+        cdef const char *name = NULL
+        cdef tvg.Tvg_Result r = tvg.tvg_lottie_animation_get_marker(
+            self._animation, <uint32_t>idx, &name)
+        py_name = name.decode('utf-8') if name is not NULL else None
+        return (_wrap_result(r), py_name)
+
+    def gen_slot(self, slot):
+        """Generate a slot ID from JSON *slot* data. Returns 0 on failure."""
+        if self._animation == NULL:
+            return 0
+        if isinstance(slot, str):
+            b = slot.encode('utf-8')
+        else:
+            b = bytes(slot)
+        cdef bytes _b = b
+        cdef const char *p = _b
+        cdef uint32_t handle = tvg.tvg_lottie_animation_gen_slot(
+            self._animation, p)
+        return <unsigned long>handle
+
+    def apply_slot(self, id):
+        """Apply the slot override identified by *id*.
+
+        *id* is the unsigned 32-bit handle returned by :meth:`gen_slot`
+        (or ``0`` to clear all active overrides). The parameter is
+        declared untyped so that Python ints in the full ``uint32_t``
+        range (0..2^32 - 1) can be accepted without Cython raising
+        ``OverflowError`` on values above ``INT_MAX``.
+        """
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef uint32_t c_id = <uint32_t><unsigned long>id
+        return _wrap_result(tvg.tvg_lottie_animation_apply_slot(
+            self._animation, c_id))
+
+    def del_slot(self, id):
+        """Delete the slot override identified by *id*.
+
+        Accepts the full ``uint32_t`` range returned by :meth:`gen_slot`
+        (see :meth:`apply_slot` for rationale).
+        """
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef uint32_t c_id = <uint32_t><unsigned long>id
+        return _wrap_result(tvg.tvg_lottie_animation_del_slot(
+            self._animation, c_id))
+
+    def set_quality(self, int value):
+        if self._animation == NULL:
+            return Result.INVALID_ARGUMENT
+        cdef uint8_t v
+        if value < 0:
+            v = 0
+        elif value > 100:
+            v = 100
+        else:
+            v = <uint8_t>value
+        return _wrap_result(tvg.tvg_lottie_animation_set_quality(
+            self._animation, v))

--- a/kivy/lib/thorvg/thorvg.pxd
+++ b/kivy/lib/thorvg/thorvg.pxd
@@ -1,0 +1,123 @@
+# cython: language_level=3
+"""
+Minimal Cython declarations for the ThorVG v1.0.4 C API (``thorvg_capi.h``).
+
+Only the surface required by Kivy's SVG, SVG-image and Lottie providers is
+declared here. See [kivy/lib/thorvg/_thorvg.pyx](_thorvg.pyx) for the wrapper
+implementation and the public Python surface in
+[kivy/lib/thorvg/__init__.py](__init__.py).
+"""
+
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, int32_t
+from libcpp cimport bool as cbool
+
+
+cdef extern from "thorvg_capi.h" nogil:
+
+    # Opaque handles - typedef'd as pointers to incomplete structs in the C
+    # header. Treat as ``void *`` on the Cython side.
+    ctypedef void *Tvg_Canvas
+    ctypedef void *Tvg_Paint
+    ctypedef void *Tvg_Animation
+    ctypedef void *Tvg_Accessor
+
+    # Enums
+    ctypedef enum Tvg_Result:
+        TVG_RESULT_SUCCESS
+        TVG_RESULT_INVALID_ARGUMENT
+        TVG_RESULT_INSUFFICIENT_CONDITION
+        TVG_RESULT_FAILED_ALLOCATION
+        TVG_RESULT_MEMORY_CORRUPTION
+        TVG_RESULT_NOT_SUPPORTED
+        TVG_RESULT_UNKNOWN
+
+    ctypedef enum Tvg_Colorspace:
+        TVG_COLORSPACE_ABGR8888
+        TVG_COLORSPACE_ARGB8888
+        TVG_COLORSPACE_ABGR8888S
+        TVG_COLORSPACE_ARGB8888S
+        TVG_COLORSPACE_UNKNOWN
+
+    ctypedef enum Tvg_Engine_Option:
+        TVG_ENGINE_OPTION_NONE
+        TVG_ENGINE_OPTION_DEFAULT
+        TVG_ENGINE_OPTION_SMART_RENDER
+
+    # Accessor traversal callback signature.
+    ctypedef cbool (*Tvg_Accessor_Func)(Tvg_Paint paint, void *data)
+
+    # --- Engine (refcounted singleton at the C layer) ---
+    Tvg_Result tvg_engine_init(unsigned threads)
+    Tvg_Result tvg_engine_term()
+    Tvg_Result tvg_engine_version(uint32_t *major, uint32_t *minor,
+                                  uint32_t *micro, const char **version)
+
+    # --- SwCanvas ---
+    Tvg_Canvas tvg_swcanvas_create(Tvg_Engine_Option op)
+    Tvg_Result tvg_swcanvas_set_target(
+        Tvg_Canvas canvas, uint32_t *buffer, uint32_t stride,
+        uint32_t w, uint32_t h, Tvg_Colorspace cs)
+
+    # --- Canvas (common) ---
+    Tvg_Result tvg_canvas_destroy(Tvg_Canvas canvas)
+    Tvg_Result tvg_canvas_add(Tvg_Canvas canvas, Tvg_Paint paint)
+    Tvg_Result tvg_canvas_remove(Tvg_Canvas canvas, Tvg_Paint paint)
+    Tvg_Result tvg_canvas_update(Tvg_Canvas canvas)
+    Tvg_Result tvg_canvas_draw(Tvg_Canvas canvas, cbool clear)
+    Tvg_Result tvg_canvas_sync(Tvg_Canvas canvas)
+
+    # --- Paint (base) ---
+    uint16_t tvg_paint_ref(Tvg_Paint paint)
+    uint16_t tvg_paint_unref(Tvg_Paint paint, cbool free)
+    Tvg_Result tvg_paint_set_opacity(Tvg_Paint paint, uint8_t opacity)
+    uint32_t tvg_paint_get_id(const Tvg_Paint paint)
+
+    # --- Picture ---
+    Tvg_Paint tvg_picture_new()
+    Tvg_Result tvg_picture_load(Tvg_Paint picture, const char *path)
+    Tvg_Result tvg_picture_load_data(
+        Tvg_Paint picture, const char *data, uint32_t size,
+        const char *mimetype, const char *rpath, cbool copy)
+    Tvg_Result tvg_picture_set_size(Tvg_Paint picture, float w, float h)
+    Tvg_Result tvg_picture_get_size(const Tvg_Paint picture,
+                                    float *w, float *h)
+    const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id)
+    Tvg_Result tvg_picture_set_accessible(Tvg_Paint picture, cbool accessible)
+
+    # --- Accessor ---
+    Tvg_Accessor tvg_accessor_new()
+    Tvg_Result tvg_accessor_del(Tvg_Accessor accessor)
+    Tvg_Result tvg_accessor_set(
+        Tvg_Accessor accessor, Tvg_Paint paint,
+        Tvg_Accessor_Func func, void *data)
+    uint32_t tvg_accessor_generate_id(const char *name)
+    const char *tvg_accessor_get_name(Tvg_Accessor accessor, uint32_t id)
+
+    # --- Animation (base) ---
+    Tvg_Result tvg_animation_set_frame(Tvg_Animation animation, float no)
+    Tvg_Paint tvg_animation_get_picture(Tvg_Animation animation)
+    Tvg_Result tvg_animation_get_total_frame(Tvg_Animation animation,
+                                             float *cnt)
+    Tvg_Result tvg_animation_get_duration(Tvg_Animation animation,
+                                          float *duration)
+    Tvg_Result tvg_animation_set_segment(Tvg_Animation animation,
+                                         float begin, float end)
+    Tvg_Result tvg_animation_del(Tvg_Animation animation)
+
+    # --- LottieAnimation ---
+    Tvg_Animation tvg_lottie_animation_new()
+    uint32_t tvg_lottie_animation_gen_slot(Tvg_Animation animation,
+                                           const char *slot)
+    Tvg_Result tvg_lottie_animation_apply_slot(Tvg_Animation animation,
+                                               uint32_t id)
+    Tvg_Result tvg_lottie_animation_del_slot(Tvg_Animation animation,
+                                             uint32_t id)
+    Tvg_Result tvg_lottie_animation_set_marker(Tvg_Animation animation,
+                                               const char *marker)
+    Tvg_Result tvg_lottie_animation_get_markers_cnt(Tvg_Animation animation,
+                                                    uint32_t *cnt)
+    Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation,
+                                               uint32_t idx,
+                                               const char **name)
+    Tvg_Result tvg_lottie_animation_set_quality(Tvg_Animation animation,
+                                                uint8_t value)

--- a/setup.py
+++ b/setup.py
@@ -264,6 +264,16 @@ if platform == 'ios':
         }
     }
 
+    thorvg_xc = join(
+        KIVY_DEPS_ROOT, 'dist', 'Frameworks', 'KivyThorVG.xcframework')
+    thorvg_fw = join(thorvg_xc, plat_arch, 'KivyThorVG.framework')
+    thorvg_headers = join(thorvg_fw, 'Headers')
+    ios_data['frameworks']['KivyThorVG'] = {
+        'path': thorvg_fw,
+        'headers': thorvg_headers,
+        'xc': thorvg_xc,
+    }
+
     ios_data['platform_arch'] = plat_arch
 
     plat_options['ios'] = ios_data
@@ -320,6 +330,7 @@ c_options['use_mesagl'] = False
 c_options['use_x11'] = False
 c_options['use_wayland'] = None
 c_options['use_gstreamer'] = None
+c_options['use_thorvg'] = None
 c_options['use_avfoundation'] = platform in ['darwin', 'ios']
 c_options['use_osx_frameworks'] = platform == 'darwin'
 c_options['use_angle_gl_backend'] = platform in ['darwin', 'ios']
@@ -857,6 +868,179 @@ def determine_angle_flags():
     return flags
 
 
+def determine_thorvg_flags():
+    """Compiler / linker flags for the internal ``kivy.lib.thorvg`` Cython
+    wrapper. The ThorVG version itself is pinned in
+    ``tools/build_thorvg.sh``; this function is version-agnostic and just
+    resolves headers + library search paths for whatever was installed
+    there.
+
+    Header + library lookup order:
+
+    1. ``KIVY_THORVG_INCLUDE_DIR`` / ``KIVY_THORVG_LIB_DIR`` environment
+       variables (set by mobile recipes - p4a, kivy-ios - and by users with
+       custom ThorVG installations).
+    2. ``$KIVY_DEPS_ROOT/dist/{include,lib,lib64}`` (the standard location
+       produced by the desktop CI build scripts and kivy-dependencies).
+
+    Linkage per platform:
+
+    * **Linux** - dynamic: ``libthorvg-1.so.*`` produced by
+      ``tools/build_thorvg.sh`` with ``THORVG_SHARED=1`` and bundled into
+      ``kivy.libs/`` by ``auditwheel repair`` during cibuildwheel. No
+      ``-lstdc++`` needed - the shared library's ``DT_NEEDED`` carries
+      the C++ runtime dependency itself.
+    * **macOS** - dynamic: links against
+      ``KivyThorVG.framework`` (wrapped from ``libthorvg-1.dylib`` by
+      ``tools/macos_framework_wrapper.sh``), embedded into the wheel
+      by ``delocate-wheel`` at cibuildwheel-repair time. The framework
+      branch mirrors SDL3's ``macos-frameworks`` path: ``-F`` +
+      ``-framework KivyThorVG`` + an ``@rpath`` entry so delocate can
+      rewrite paths to ``@loader_path/../.dylibs/`` in the repaired
+      wheel.
+    * **Windows** - static: ``thorvg.lib`` normalised by
+      ``tools/build_thorvg.sh``. Kivy's Windows wheel pipeline does not
+      run a wheel-repair step, so dynamic linking would force a separate
+      ``kivy_deps.thorvg`` package - out of scope for this PR.
+    * **iOS / Android** - handled by mobile recipes / cibuildwheel (not
+      this function's concern beyond ``KIVY_THORVG_*`` env var support).
+    """
+    # macOS (desktop): look for ``KivyThorVG.framework`` first. This is
+    # the path produced by ``tools/build_macos_dependencies.sh`` and
+    # used by every standard macOS wheel build. We short-circuit to
+    # framework-style flags here (same shape as SDL3's
+    # ``macos-frameworks`` branch above) instead of threading an
+    # ``is_framework`` boolean through the rest of this function, so
+    # the downstream ``library_dirs`` / ``-l`` logic stays exclusively
+    # for dylib + static-archive consumers (Linux / Windows / dev
+    # override).
+    #
+    # If the framework is absent - e.g. a developer pointed
+    # ``KIVY_THORVG_LIB_DIR`` at a raw Meson ``dist/lib/``, or
+    # ``c_options['use_osx_frameworks']`` was explicitly disabled - we
+    # fall through to the generic dylib path, which still produces a
+    # working build (just without delocate-wheel's framework-embedding
+    # magic).
+    if platform == 'ios':
+        # iOS: link against the per-slice KivyThorVG.framework from inside
+        # KivyThorVG.xcframework.  plat_options['ios']['frameworks'] already
+        # resolved the correct slice path (ios-arm64 for device,
+        # ios-arm64_x86_64-simulator for simulator) via plat_arch.
+        # No TVG_STATIC — the xcframework slice is a shared dylib, not a
+        # static archive.  The @executable_path/Frameworks rpath matches
+        # Kivy's iOS app bundle layout (same as SDL3 on iOS).
+        ios_thorvg = plat_options['ios']['frameworks']['KivyThorVG']
+        thorvg_fw_dir = dirname(ios_thorvg['path'])
+        return {
+            'include_dirs': [ios_thorvg['headers']],
+            'library_dirs': [],
+            'libraries': [],
+            'extra_compile_args': [],
+            'extra_link_args': [
+                '-F', thorvg_fw_dir,
+                '-framework', 'KivyThorVG',
+                '-Wl,-rpath,@executable_path/Frameworks',
+            ],
+            'define_macros': [],
+        }
+
+    if platform == 'darwin' and c_options['use_osx_frameworks']:
+        if KIVY_DEPS_ROOT:
+            thorvg_fw_root = join(KIVY_DEPS_ROOT, 'dist', 'Frameworks')
+        else:
+            thorvg_fw_root = environ.get(
+                'KIVY_THORVG_FRAMEWORKS_SEARCH_PATH',
+                '/Library/Frameworks',
+            )
+        thorvg_fw = join(thorvg_fw_root, 'KivyThorVG.framework')
+        if exists(thorvg_fw):
+            return {
+                'include_dirs': [join(thorvg_fw, 'Headers')],
+                'library_dirs': [],
+                'libraries': [],
+                'extra_compile_args': ['-F{}'.format(thorvg_fw_root)],
+                'extra_link_args': [
+                    '-F{}'.format(thorvg_fw_root),
+                    '-Xlinker', '-rpath',
+                    '-Xlinker', thorvg_fw_root,
+                    '-Xlinker', '-headerpad',
+                    '-Xlinker', '190',
+                    '-framework', 'KivyThorVG',
+                ],
+                'define_macros': [],
+            }
+
+    # ThorVG's Meson build declares the library as ``thorvg-<MAJOR>``,
+    # which produces ``libthorvg-1.so.*`` (Linux), ``libthorvg-1.a``
+    # (static), and ``libthorvg-1.dylib`` (macOS). On Windows the static
+    # archive is normalised to ``thorvg.lib`` by ``build_thorvg.sh`` so
+    # the bare name ``thorvg`` resolves.
+    if platform == 'win32':
+        thorvg_lib = 'thorvg'
+    else:
+        thorvg_lib = 'thorvg-1'
+
+    flags = {
+        'include_dirs': [],
+        'library_dirs': [],
+        'libraries': [thorvg_lib],
+        'extra_compile_args': [],
+        'extra_link_args': [],
+        'define_macros': [],
+    }
+
+    # ``TVG_STATIC`` makes ``thorvg_capi.h`` drop the Windows
+    # __declspec(dllimport) annotations and the Unix visibility attributes.
+    # It is required when linking a static archive; when linking a shared
+    # library it must be omitted so the visibility attributes stay active
+    # and dynamic symbol resolution works.
+    #
+    # Windows stays static (Kivy has no wheel-repair step there).
+    # macOS desktop is shared via the framework branch above - the
+    # fallback dylib path reaches this branch only when the framework
+    # is absent, in which case we treat it as shared too (no TVG_STATIC).
+    # iOS returns early above via the framework path (shared dylib —
+    # no TVG_STATIC).  Windows and Android still link statically.
+    if platform in ('win32', 'android'):
+        flags['define_macros'].append(('TVG_STATIC', '1'))
+
+    explicit_include = environ.get('KIVY_THORVG_INCLUDE_DIR')
+    explicit_lib = environ.get('KIVY_THORVG_LIB_DIR')
+    if explicit_include:
+        flags['include_dirs'].append(explicit_include)
+    if explicit_lib:
+        flags['library_dirs'].append(explicit_lib)
+
+    if KIVY_DEPS_ROOT:
+        dist = join(KIVY_DEPS_ROOT, 'dist')
+        # ThorVG's meson install places headers under
+        # ``include/thorvg-1/thorvg_capi.h`` (versioned subdir). Add both
+        # that and the parent ``include`` so a user who flattens the
+        # install, or a custom prefix layout, still resolves the header.
+        flags['include_dirs'].append(join(dist, 'include', 'thorvg-1'))
+        flags['include_dirs'].append(join(dist, 'include'))
+        flags['library_dirs'].append(join(dist, 'lib'))
+        flags['library_dirs'].append(join(dist, 'lib64'))
+
+    # ThorVG is C++. A static archive needs the C++ runtime linked
+    # explicitly on Unix-like systems. On Linux a shared libthorvg-1.so
+    # already carries ``libstdc++.so.6`` in its own ``DT_NEEDED``, so the
+    # flag is redundant for the default shared path - but we keep it so
+    # a user who supplies a static ThorVG via ``KIVY_THORVG_LIB_DIR``
+    # still gets a working link. auditwheel / manylinux treats
+    # ``libstdc++.so.6`` as a system-provided library (not vendored), so
+    # the extra ``DT_NEEDED`` entry is free. Windows (MSVC) pulls the
+    # runtime in automatically. Mobile toolchains (Android NDK, iOS) use
+    # libc++ and arrange the runtime themselves in the recipe /
+    # cibuildwheel config, not here.
+    if platform == 'darwin':
+        flags['extra_link_args'].append('-lc++')
+    elif platform not in ('win32', 'android', 'ios'):
+        flags['extra_link_args'].append('-lstdc++')
+
+    return flags
+
+
 def determine_gl_flags():
     kivy_graphics_include = join(src_path, 'kivy', 'include')
     flags = {'include_dirs': [kivy_graphics_include], 'libraries': []}
@@ -1333,6 +1517,50 @@ if c_options['use_gstreamer']:
     sources['lib/gstplayer/_gstplayer.pyx'] = merge(
         base_flags, gst_flags, {
             'depends': ['lib/gstplayer/_gstplayer.h']})
+
+# ThorVG wrapper (kivy.lib.thorvg._thorvg). Version is pinned in
+# tools/build_thorvg.sh.
+#
+# Matches the auto-detection pattern used by ``use_gstreamer`` /
+# ``use_sdl3``: if ``use_thorvg`` is left at ``None`` we probe for
+# ``thorvg_capi.h`` under the search paths returned by
+# ``determine_thorvg_flags()`` and only enable the wrapper when found.
+# This keeps tree-ish dev builds and the existing Kivy CI workflows
+# (which do not yet build ThorVG as a dep) working: the wrapper simply
+# doesn't get compiled if ThorVG isn't installed.
+#
+# Users / mobile recipes / the lightweight wrapper gate opt in explicitly
+# by setting ``USE_THORVG=1`` / ``KIVY_THORVG_INCLUDE_DIR`` /
+# ``KIVY_THORVG_LIB_DIR`` so the detect succeeds.
+thorvg_flags = determine_thorvg_flags()
+if c_options['use_thorvg'] is None:
+    header_found = any(
+        exists(join(inc, 'thorvg_capi.h'))
+        for inc in thorvg_flags['include_dirs']
+    )
+    if header_found:
+        print('ThorVG headers detected - building kivy.lib.thorvg wrapper')
+        c_options['use_thorvg'] = True
+    else:
+        print(
+            'ThorVG headers not found; skipping kivy.lib.thorvg wrapper. '
+            'Set KIVY_THORVG_INCLUDE_DIR / KIVY_THORVG_LIB_DIR (direct '
+            'paths), KIVY_DEPS_ROOT (expects '
+            '$KIVY_DEPS_ROOT/dist/include/thorvg-1/thorvg_capi.h), or '
+            'USE_THORVG=1 to force a build attempt.'
+        )
+        c_options['use_thorvg'] = False
+
+if c_options['use_thorvg']:
+    sources['lib/thorvg/_thorvg.pyx'] = merge(
+        base_flags, thorvg_flags, {
+            'depends': ['lib/thorvg/thorvg.pxd'],
+            # Compile as C++ so the ThorVG C API header's `bool` return
+            # types (`#include <stdbool.h>` vs C++ `bool`) have a
+            # consistent ABI with the ThorVG library, which is itself
+            # compiled as C++.
+            'language': 'c++',
+        })
 
 # -----------------------------------------------------------------------------
 # extension modules

--- a/tools/build_ios_dependencies.sh
+++ b/tools/build_ios_dependencies.sh
@@ -1,5 +1,10 @@
 set -e -x
 
+# Absolute path to the repo root.  Captured before any pushd so we can
+# locate tools/build_thorvg.sh and tools/macos_framework_wrapper.sh
+# regardless of which sub-directory we are in during the build.
+_REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
 # iOS SDL3
 IOS__SDL3__VERSION="3.4.2"
 IOS__SDL3__URL="https://github.com/libsdl-org/SDL/releases/download/release-$IOS__SDL3__VERSION/SDL3-$IOS__SDL3__VERSION.tar.gz"
@@ -138,5 +143,49 @@ xcodebuild -create-xcframework \
     -framework Xcode/SDL_ttf/build/Release-iphonesimulator.xcarchive/Products/Library/Frameworks/SDL3_ttf.framework \
     -output ../../dist/Frameworks/SDL3_ttf.xcframework
 popd
+
+# ---------------------------------------------------------------------------
+# Build ThorVG — two SDK slices → per-slice .framework → KivyThorVG.xcframework
+#
+# build_thorvg.sh handles download + Meson cross-compile for each slice.
+# macos_framework_wrapper.sh wraps the resulting dylib into a non-versioned
+# .framework bundle (rewrites LC_ID_DYLIB to @rpath/...).
+# xcodebuild -create-xcframework then merges both frameworks into one
+# xcframework that add-ios-frameworks.py picks up automatically.
+#
+# The THORVG_BUILD_ROOT is shared across both slices so the source tarball
+# is only downloaded once; build_thorvg.sh creates a per-slice build
+# directory (build-iphoneos / build-iphonesimulator) inside that root.
+# ---------------------------------------------------------------------------
+echo "-- Build ThorVG (universal iOS XCFramework)"
+
+_THORVG_BUILD_ROOT="$(pwd)/../dist/thorvg-build"
+
+for _slice in iphoneos iphonesimulator; do
+    _thorvg_prefix="$(pwd)/../dist/thorvg-${_slice}"
+
+    THORVG_IOS="${_slice}" \
+    THORVG_BUILD_ROOT="${_THORVG_BUILD_ROOT}" \
+    THORVG_INSTALL_PREFIX="${_thorvg_prefix}" \
+    bash "${_REPO_ROOT}/tools/build_thorvg.sh"
+
+    mkdir -p "${_thorvg_prefix}/Frameworks"
+
+    # Find the real dylib (not the symlink) produced by Meson.
+    _thorvg_dylib=$(find "${_thorvg_prefix}/lib" -maxdepth 1 \
+        -name 'libthorvg-*.dylib' ! -type l | head -n1)
+
+    FRAMEWORK_MIN_OS_VERSION=16.0 \
+    bash "${_REPO_ROOT}/tools/macos_framework_wrapper.sh" \
+        "${_thorvg_dylib}" \
+        KivyThorVG \
+        "${_thorvg_prefix}/Frameworks" \
+        "${_thorvg_prefix}/include/thorvg-1"
+done
+
+xcodebuild -create-xcframework \
+    -framework "../dist/thorvg-iphoneos/Frameworks/KivyThorVG.framework" \
+    -framework "../dist/thorvg-iphonesimulator/Frameworks/KivyThorVG.framework" \
+    -output "../dist/Frameworks/KivyThorVG.xcframework"
 
 popd

--- a/tools/build_thorvg.sh
+++ b/tools/build_thorvg.sh
@@ -1,0 +1,432 @@
+#!/bin/bash
+# Builds ThorVG and installs it into Kivy's shared dependencies tree so
+# that setup.py can link ``kivy.lib.thorvg._thorvg`` against it. Produces
+# a static archive by default; set ``THORVG_SHARED=1`` for a shared
+# library (used by Linux + macOS desktop wheels).
+#
+# This script is the single source of truth for:
+#   * the pinned ThorVG version,
+#   * the Meson build options (engine / loaders / extras / static-vs-shared)
+#     that the ``kivy.lib.thorvg._thorvg`` Cython wrapper expects, and
+#   * the ugly platform-specific glue (Windows link.exe collision, macOS
+#     universal2 via multi-arch Apple Clang, Ubuntu multiarch libdir)
+#     that we previously had to duplicate in multiple CI workflows.
+#
+# Inputs (all optional):
+#   THORVG_VERSION              ThorVG git tag to build (default 1.0.4)
+#   THORVG_BUILD_ROOT           Source/build scratch dir
+#                               (default: $(pwd)/kivy-dependencies/build/thorvg)
+#   THORVG_INSTALL_PREFIX       Final install prefix
+#                               (default: $(pwd)/kivy-dependencies/dist)
+#   THORVG_SHARED               "1" to build a shared library
+#                               (``--default-library=shared``) instead of the
+#                               default static archive. Kivy's desktop wheels
+#                               use shared on Linux (bundled into
+#                               ``kivy.libs/`` by ``auditwheel repair``) and
+#                               on macOS (wrapped as ``KivyThorVG.framework``
+#                               and embedded by ``delocate-wheel``). Windows
+#                               stays on the static default because Kivy's
+#                               Windows pipeline does not run a wheel-repair
+#                               step. Default: "0".
+#
+#                               Note: ``THORVG_SHARED`` only flips
+#                               ``--default-library``. The (confusingly named)
+#                               ThorVG ``-Dstatic`` Meson option controls
+#                               loader-plugin bundling, not library kind, and
+#                               is *always* passed as ``true`` below so the
+#                               bundled LodePNG / JPGd codecs are linked into
+#                               libthorvg directly on every platform.
+#   THORVG_MACOS_UNIVERSAL      "1" to build a universal2 (x86_64 + arm64)
+#                               archive/dylib on macOS by passing both
+#                               ``-arch`` flags to Apple Clang in a single
+#                               meson invocation (same trick libpng uses via
+#                               ``CMAKE_OSX_ARCHITECTURES="x86_64;arm64"``).
+#                               Ignored on non-macOS and ignored when
+#                               THORVG_IOS is set. Default: "1" on macOS
+#                               (matches libpng in the same tree).
+#   THORVG_IOS                  When set to "iphoneos" or "iphonesimulator",
+#                               cross-compile for that iOS SDK slice instead
+#                               of building for the macOS host.  Full Xcode
+#                               must be installed and selected via
+#                               ``xcode-select`` (the iphoneos /
+#                               iphonesimulator SDKs are not shipped with
+#                               the Command Line Tools package alone).
+#
+#                               iOS builds always force THORVG_SHARED=1:
+#                               the resulting dylib must be wrapped into a
+#                               ``.framework`` bundle by
+#                               ``tools/macos_framework_wrapper.sh`` and
+#                               assembled into an XCFramework.  A static
+#                               archive cannot be used as an xcframework
+#                               slice.
+#
+#                               Deployment target: iOS 16.0 (matches the
+#                               ANGLE xcframework — the highest minimum
+#                               already present in the Kivy iOS bundle).
+#
+#                               THORVG_MACOS_UNIVERSAL is forced to 0 when
+#                               this is set. Default: "" (disabled; builds
+#                               for the host platform).
+#
+# Requires ``meson``, ``ninja``, ``curl``, ``tar``, and a working C++14
+# toolchain on PATH. On Windows, the caller must have already sourced the
+# MSVC environment (e.g. via ``ilammy/msvc-dev-cmd``).
+# On iOS (THORVG_IOS set), full Xcode is also required (xcrun must resolve
+# the named SDK).
+
+set -e -x
+
+# Absolute path to this script's directory, used to locate cross-files
+# (tools/meson-cross-ios-*.ini) regardless of CWD.
+_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+THORVG_VERSION="${THORVG_VERSION:-1.0.4}"
+THORVG_BUILD_ROOT="${THORVG_BUILD_ROOT:-$(pwd)/kivy-dependencies/build/thorvg}"
+THORVG_INSTALL_PREFIX="${THORVG_INSTALL_PREFIX:-$(pwd)/kivy-dependencies/dist}"
+THORVG_SHARED="${THORVG_SHARED:-0}"
+THORVG_IOS="${THORVG_IOS:-}"
+
+# Detect Windows (git-bash / msys / cygwin) so we can keep the rest of the
+# script POSIX-style while still emitting .lib / handling link.exe.
+IS_WINDOWS=0
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*) IS_WINDOWS=1 ;;
+esac
+if [ "${OS:-}" = "Windows_NT" ] && [ "$IS_WINDOWS" = "0" ]; then
+  IS_WINDOWS=1
+fi
+
+IS_MACOS=0
+if [ "$(uname -s 2>/dev/null || echo)" = "Darwin" ]; then
+  IS_MACOS=1
+fi
+
+# Fast-fail with an actionable message if the tooling is missing. This is
+# cheaper than parsing meson/ninja output later.
+_missing=""
+for tool in meson ninja curl tar; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    _missing="$_missing $tool"
+  fi
+done
+if [ -n "$_missing" ]; then
+  echo "FATAL: build_thorvg.sh requires these tools on PATH:$_missing" >&2
+  echo "  On CI, install them in the workflow step that precedes this" >&2
+  echo "  script, e.g.:" >&2
+  echo "    pip install --upgrade meson ninja      # cross-platform" >&2
+  echo "    apt-get install -y meson ninja-build   # Ubuntu / Debian" >&2
+  echo "    brew install meson ninja               # macOS" >&2
+  exit 1
+fi
+
+# Default to universal2 on macOS so the static archive matches the other
+# dependencies (SDL3, libpng) that ``build_macos_dependencies.sh`` already
+# produces universal2. The caller can opt out for a single-arch local
+# build via ``THORVG_MACOS_UNIVERSAL=0``.
+# When THORVG_IOS is set we are cross-compiling for a specific iOS SDK
+# slice (not the macOS host), so the universal2 path is irrelevant and
+# THORVG_SHARED is forced to 1 — the dylib must be wrapped into a
+# .framework bundle; a static archive cannot serve as an xcframework slice.
+if [ -n "$THORVG_IOS" ]; then
+  THORVG_MACOS_UNIVERSAL=0
+  THORVG_SHARED=1
+elif [ "$IS_MACOS" = "1" ]; then
+  THORVG_MACOS_UNIVERSAL="${THORVG_MACOS_UNIVERSAL:-1}"
+else
+  THORVG_MACOS_UNIVERSAL=0
+fi
+
+mkdir -p "$THORVG_BUILD_ROOT"
+mkdir -p "$THORVG_INSTALL_PREFIX"
+
+# ---------------------------------------------------------------------------
+# 1. Fetch + extract the ThorVG source tarball (cache-friendly).
+# ---------------------------------------------------------------------------
+_THORVG_SRC_DIR="$THORVG_BUILD_ROOT/thorvg-$THORVG_VERSION"
+_THORVG_TARBALL="$THORVG_BUILD_ROOT/thorvg-$THORVG_VERSION.tar.gz"
+
+if [ ! -d "$_THORVG_SRC_DIR" ]; then
+  if [ ! -f "$_THORVG_TARBALL" ]; then
+    curl -fsSL \
+      -o "$_THORVG_TARBALL" \
+      "https://github.com/thorvg/thorvg/archive/refs/tags/v${THORVG_VERSION}.tar.gz"
+  fi
+  tar -xzf "$_THORVG_TARBALL" -C "$THORVG_BUILD_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Windows: hide Git-for-Windows's GNU link.exe so Meson picks up MSVC's.
+#
+# ``ilammy/msvc-dev-cmd`` prepends MSVC's link.exe to cmd/pwsh PATH, but
+# steps that run under ``shell: bash`` (including this script) resolve
+# Git-for-Windows's ``/usr/bin/link.exe`` (GNU ld-wrapper) first. Meson
+# probes link.exe during MSVC detection and bails with
+# ``Found GNU link.exe instead of MSVC link.exe``.
+# ---------------------------------------------------------------------------
+if [ "$IS_WINDOWS" = "1" ]; then
+  for candidate in \
+    "/c/Program Files/Git/usr/bin/link.exe" \
+    "/usr/bin/link.exe" \
+    "/usr/bin/link"; do
+    if [ -f "$candidate" ] && [ ! -f "${candidate}.disabled" ]; then
+      mv "$candidate" "${candidate}.disabled"
+      echo "Disabled $candidate"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Configure + compile + install.
+#
+# Meson option notes (keep in sync with .github/workflows/test_thorvg_wrapper.yml):
+#   -Dextra=           disables the two defaulted ``extra`` features
+#                      (``lottie_exp``, ``openmp``). The CPU renderer
+#                      unconditionally ``#include <omp.h>`` when the
+#                      ``openmp`` extra is enabled, but Apple Clang does
+#                      not ship libomp, and the wrapper already calls
+#                      ``tvg_engine_init(SW, threads=0)``, so OpenMP is
+#                      dead code for Kivy. ``lottie_exp`` pulls in the
+#                      JerryScript JS engine for Lottie expression support
+#                      (~130 extra compile units); none of the Kivy
+#                      providers (svg / svg-image / lottie) need it.
+#   -Dloaders=...      svg + lottie + ttf for vector content, plus png +
+#                      jpg so that raster assets *embedded* in SVG
+#                      data-URIs and Lottie ``<image>`` layers decode.
+#                      Combined with ``-Dstatic=true`` below, ThorVG
+#                      links its **bundled** self-contained codecs
+#                      (LodePNG for PNG, JPGd for JPEG, in
+#                      ``src/loaders/{png,jpg}/``) directly into
+#                      libthorvg on every platform - no external
+#                      ``libpng`` / ``libturbojpeg`` runtime
+#                      dependency, no pkg-config / Homebrew detection
+#                      to break universal2 builds. See the
+#                      ``-Dstatic=true`` note below for the actual
+#                      switch that selects the bundled path.
+#   -Dstatic=true      Loader-plugin bundling switch (poorly named:
+#                      this is *not* the same as
+#                      ``--default-library=static``). When ``true``,
+#                      ``src/loaders/meson.build`` skips
+#                      ``subdir('external_png')`` /
+#                      ``subdir('external_jpg')`` and unconditionally
+#                      compiles the bundled codecs in
+#                      ``src/loaders/{png,jpg}/``. When ``false`` (the
+#                      ThorVG default), Meson tries pkg-config and
+#                      then falls back to ``cc.find_library('turbojpeg')``
+#                      / ``cc.find_library('png')``, which uses the
+#                      compiler's link search path
+#                      (``/usr/local/lib`` on Intel macOS,
+#                      ``/opt/homebrew/lib`` on Apple Silicon) and
+#                      links Homebrew's single-arch dylibs into our
+#                      universal2 ``libthorvg-1.dylib`` - which then
+#                      fails with ``found architecture 'x86_64',
+#                      required architecture 'arm64'`` (or vice versa)
+#                      on whichever slice Homebrew did not provide.
+#                      We always force ``true`` below, regardless of
+#                      ``THORVG_SHARED``, so libthorvg is fully
+#                      self-contained on Linux / macOS / Windows.
+#   --libdir=lib       Meson on Debian/Ubuntu defaults to
+#                      ``lib/x86_64-linux-gnu/`` multiarch, which setup.py
+#                      does not probe. Force a flat install.
+# ---------------------------------------------------------------------------
+if [ "$THORVG_SHARED" = "1" ]; then
+  _THORVG_DEFAULT_LIBRARY="shared"
+else
+  _THORVG_DEFAULT_LIBRARY="static"
+fi
+
+_thorvg_configure_and_install() {
+  local build_dir="$1"
+  local prefix="$2"
+  shift 2
+
+  pushd "$_THORVG_SRC_DIR"
+
+  # Clean stale build dir from previous invocations (idempotent CI reruns).
+  rm -rf "$build_dir"
+
+  meson setup "$build_dir" \
+    --buildtype=release \
+    --default-library="$_THORVG_DEFAULT_LIBRARY" \
+    --prefix="$prefix" \
+    --libdir=lib \
+    -Dlog=false \
+    -Dstatic=true \
+    -Dthreads=false \
+    -Dtests=false \
+    -Dbindings=capi \
+    -Dloaders=svg,lottie,png,jpg,ttf \
+    -Dengines=cpu \
+    -Dextra= \
+    "$@"
+
+  meson compile -C "$build_dir"
+  meson install -C "$build_dir"
+
+  popd
+}
+
+if [ -n "$THORVG_IOS" ]; then
+  # ---------------------------------------------------------------------------
+  # iOS cross-compile path (THORVG_IOS=iphoneos | iphonesimulator).
+  #
+  # The SDK sysroot is resolved at runtime via xcrun so the build picks up
+  # the SDK from whichever Xcode version is active (xcode-select -p).
+  #
+  # Deployment target: iOS 16.0.  This matches ANGLE xcframework
+  # (the highest minimum already in the Kivy iOS bundle; SDL3 is 11.0 but
+  # ANGLE at 16.0 is the effective floor for the whole bundle).
+  #
+  # -lc++ rationale: same as the macOS universal2 path below — Meson links
+  # the final shared library with clang (not clang++), skipping libc++ auto-
+  # linking.  Explicit -lc++ resolves std::__1::* against the SDK-bundled
+  # libc++.tbd.
+  # ---------------------------------------------------------------------------
+  case "$THORVG_IOS" in
+    iphoneos)
+      _IOS_ARCHS="-arch arm64"
+      _IOS_MINVER="-mios-version-min=16.0"
+      _IOS_CROSS_FILE="$_SCRIPT_DIR/meson-cross-ios-device.ini"
+      _IOS_LABEL="iOS device (arm64, iphoneos)"
+      ;;
+    iphonesimulator)
+      _IOS_ARCHS="-arch arm64 -arch x86_64"
+      _IOS_MINVER="-mios-simulator-version-min=16.0"
+      _IOS_CROSS_FILE="$_SCRIPT_DIR/meson-cross-ios-sim.ini"
+      _IOS_LABEL="iOS Simulator (universal arm64+x86_64, iphonesimulator)"
+      ;;
+    *)
+      echo "FATAL: THORVG_IOS must be 'iphoneos' or 'iphonesimulator', got: '$THORVG_IOS'" >&2
+      exit 1
+      ;;
+  esac
+
+  _IOS_SDK_PATH="$(xcrun --sdk "$THORVG_IOS" --show-sdk-path)"
+  echo "-- Build ThorVG ($_IOS_LABEL)"
+  echo "   SDK        : $_IOS_SDK_PATH"
+  echo "   Cross-file : $_IOS_CROSS_FILE"
+
+  _thorvg_configure_and_install "build-$THORVG_IOS" "$THORVG_INSTALL_PREFIX" \
+    --cross-file "$_IOS_CROSS_FILE" \
+    -Dc_args="-isysroot $_IOS_SDK_PATH $_IOS_ARCHS $_IOS_MINVER" \
+    -Dcpp_args="-isysroot $_IOS_SDK_PATH $_IOS_ARCHS $_IOS_MINVER" \
+    -Dc_link_args="-isysroot $_IOS_SDK_PATH $_IOS_ARCHS $_IOS_MINVER" \
+    -Dcpp_link_args="-isysroot $_IOS_SDK_PATH $_IOS_ARCHS $_IOS_MINVER -lc++"
+
+  # Quick sanity check immediately after the build (before framework wrap).
+  # The full post-install section below also verifies the dylib exists.
+  _ios_dylib=$(find "$THORVG_INSTALL_PREFIX/lib" -maxdepth 2 \
+    -name 'libthorvg*.dylib' 2>/dev/null | head -n1)
+  if [ -n "$_ios_dylib" ]; then
+    echo "--- iOS dylib architectures (lipo) ---"
+    lipo -info "$_ios_dylib" || true
+    echo "--- iOS dylib deployment target (LC_BUILD_VERSION / LC_VERSION_MIN) ---"
+    otool -l "$_ios_dylib" | grep -A5 "LC_BUILD_VERSION\|LC_VERSION_MIN_IPHONEOS" || true
+    echo "--- iOS dylib install name (LC_ID_DYLIB) ---"
+    otool -D "$_ios_dylib" || true
+  fi
+
+elif [ "$THORVG_MACOS_UNIVERSAL" = "1" ]; then
+  # Single-invocation universal2 build (matches libpng's CMake
+  # ``-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"`` path in
+  # tools/build_macos_dependencies.sh).
+  #
+  # Passing multiple ``-arch`` flags to Apple Clang produces universal2
+  # object files in a single compile; ``ar`` / ``libtool`` then archive
+  # them directly into a fat static library - no lipo-merge, no second
+  # meson invocation, and critically no arm64 cross-compile sanity check
+  # that would fail on Intel runners (``macos-15-intel`` in
+  # test_osx_python.yml) where Meson can't execute the freshly built
+  # arm64 ``sanitycheckcpp.exe`` binary (``[Errno 86] Bad CPU type in
+  # executable``). Universal2 binaries run natively on both arches so
+  # the sanity check succeeds regardless of host CPU.
+  echo "-- Build ThorVG (universal2 via single meson invocation)"
+  # ``-lc++`` on the link line is only needed for the shared build
+  # (``THORVG_SHARED=1`` -> libthorvg-1.1.dylib). Meson invokes Apple
+  # Clang as ``clang`` (not ``clang++``) for the final link step of
+  # this target, which skips libc++ auto-linking and leaves every
+  # ``std::__1::*`` reference unresolved on both slices; the error
+  # surfaces first on the x86_64 slice with
+  # ``Undefined symbols for architecture x86_64: "std::__1::mutex::lock()"``.
+  # Adding ``-lc++`` explicitly resolves libc++ via ``/usr/lib/libc++.dylib``
+  # (universal fat binary shipped by the Xcode CLT) for both slices.
+  # For the static archive path (``ar`` just bundles .o files, no link
+  # resolution) the flag is harmless - ``ar`` ignores ``-l*``.
+  _thorvg_configure_and_install "build" "$THORVG_INSTALL_PREFIX" \
+    -Dc_args="-arch x86_64 -arch arm64" \
+    -Dcpp_args="-arch x86_64 -arch arm64" \
+    -Dc_link_args="-arch x86_64 -arch arm64" \
+    -Dcpp_link_args="-arch x86_64 -arch arm64 -lc++"
+
+  # Verify the produced archive / dylib is actually fat. ``lipo -info``
+  # covers both ``libthorvg-1.a`` (static path) and
+  # ``libthorvg-1.dylib`` (``THORVG_SHARED=1`` path); Apple's linker
+  # handles universal2 for both output kinds given the multi-``-arch``
+  # flags above.
+  _fat_bin=$(find "$THORVG_INSTALL_PREFIX/lib" -maxdepth 2 \
+    \( -name 'libthorvg*.a' -o -name 'libthorvg*.dylib' \) | head -n1)
+  if [ -n "$_fat_bin" ]; then
+    lipo -info "$_fat_bin" || true
+  fi
+else
+  _thorvg_configure_and_install "build" "$THORVG_INSTALL_PREFIX"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Post-install: verify and (for static builds) normalise the archive name.
+#
+# Static builds:
+#   Rename the produced archive to ``libthorvg.a`` (Unix) / ``thorvg.lib``
+#   (Windows) so that setup.py's ``libraries=['thorvg']`` resolves cleanly
+#   without having to know the ThorVG soversion.
+#
+# Shared builds (``THORVG_SHARED=1``):
+#   No renaming - setup.py uses ``-lthorvg-1`` which matches Meson's
+#   versioned output (``libthorvg-1.so.X`` on Linux, ``libthorvg-1.dylib``
+#   on macOS). ``auditwheel repair`` / ``delocate-wheel`` / the framework
+#   wrapper in ``build_macos_dependencies.sh`` take it from there. We still
+#   fail fast here if Meson silently produced only a static archive.
+# ---------------------------------------------------------------------------
+_libdir="$THORVG_INSTALL_PREFIX/lib"
+echo "--- Contents of $_libdir ---"
+ls -lR "$_libdir" || true
+
+if [ "$THORVG_SHARED" = "1" ]; then
+  if [ "$IS_MACOS" = "1" ]; then
+    _shared_files=$(find "$_libdir" -maxdepth 3 -name 'libthorvg*.dylib' \
+      2>/dev/null)
+  else
+    _shared_files=$(find "$_libdir" -maxdepth 3 -name 'libthorvg*.so*' \
+      2>/dev/null)
+  fi
+  if [ -z "$_shared_files" ]; then
+    echo "FATAL: THORVG_SHARED=1 but no shared ThorVG library found under $_libdir" >&2
+    exit 1
+  fi
+  echo "--- ThorVG shared library (THORVG_SHARED=1) ---"
+  echo "$_shared_files"
+  # For iOS slices, show the dynamic library dependencies so the caller
+  # can confirm the dylib is self-contained (no Homebrew paths leaked in)
+  # before passing it to macos_framework_wrapper.sh.
+  if [ -n "$THORVG_IOS" ]; then
+    echo "--- iOS dylib link dependencies (otool -L) ---"
+    otool -L $(echo "$_shared_files" | head -n1) || true
+  fi
+elif [ "$IS_WINDOWS" = "1" ]; then
+  src=$(find "$_libdir" -maxdepth 3 \
+    \( -name 'thorvg*.lib' -o -name 'libthorvg*.a' \) 2>/dev/null | head -n1)
+  [ -n "$src" ] || {
+    echo "FATAL: no ThorVG static archive found under $_libdir" >&2
+    exit 1
+  }
+  cp "$src" "$_libdir/thorvg.lib"
+else
+  src=$(find "$_libdir" -maxdepth 3 -name 'libthorvg*.a' 2>/dev/null | head -n1)
+  [ -n "$src" ] || {
+    echo "FATAL: no ThorVG static archive found under $_libdir" >&2
+    exit 1
+  }
+  cp "$src" "$_libdir/libthorvg.a"
+fi
+
+echo "--- After normalisation ---"
+ls -l "$_libdir"

--- a/tools/macos_framework_wrapper.sh
+++ b/tools/macos_framework_wrapper.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Wrap a macOS / iOS Mach-O dylib into an Apple ``.framework`` bundle.
+#
+# Kivy's third-party deps mostly ship as ``.framework`` bundles built
+# by CMake (libpng, via ``-DPNG_FRAMEWORK=ON``) or Xcode (SDL3 family,
+# via ``xcodebuild``). ThorVG is Meson-based and only produces a plain
+# ``libthorvg-1.dylib``; this helper rewraps that dylib so it can be
+# linked with ``-framework <Name>`` and embedded into Kivy wheels by:
+#
+#   * ``delocate-wheel`` on macOS desktop (called from
+#     ``.github/workflows/osx_wheels_app.yml`` via
+#     ``CIBW_REPAIR_WHEEL_COMMAND_MACOS``), and
+#   * ``xcodebuild -create-xcframework`` on iOS (pending
+#     STAGE 2 changes to ``tools/build_ios_dependencies.sh``;
+#     iOS calls this helper once per slice, then combines
+#     the per-slice frameworks into a single XCFramework).
+#
+# Usage
+# -----
+# ::
+#
+#   macos_framework_wrapper.sh <dylib> <framework_name> <output_dir> \
+#     <headers_dir> [<short_version>] [<bundle_id>]
+#
+# Arguments:
+#   <dylib>           Path to the input dylib (e.g. ``libthorvg-1.dylib``).
+#                     Must already be a valid Mach-O (universal2 on
+#                     macOS desktop, single-slice on iOS). Not mutated
+#                     in-place; the helper works on a copy.
+#   <framework_name>  Name of the produced framework (no suffix), e.g.
+#                     ``KivyThorVG``.
+#   <output_dir>      Directory to create the framework under. Must
+#                     already exist.
+#   <headers_dir>     Directory whose contents are copied (recursively)
+#                     into ``<Name>.framework/Headers/``. For ThorVG:
+#                     ``<prefix>/include/thorvg-1``.
+#   <short_version>   Optional ``CFBundleShortVersionString`` (default
+#                     ``1.0``).
+#   <bundle_id>       Optional ``CFBundleIdentifier`` (default
+#                     ``org.kivy.<framework_name>``).
+#
+# Environment:
+#   FRAMEWORK_MIN_OS_VERSION  If set (typically on iOS), adds a
+#                             ``MinimumOSVersion`` key to Info.plist so
+#                             the resulting framework passes App Store
+#                             validation. Ignored on macOS desktop.
+#
+# Layout
+# ------
+# Non-versioned bundle (iOS cannot consume versioned bundles, and a
+# flat layout also sidesteps delocate-wheel's Versions/ handling
+# quirks)::
+#
+#   <output_dir>/<Name>.framework/
+#     <Name>                  # dylib, renamed; LC_ID_DYLIB rewritten to
+#                             #   @rpath/<Name>.framework/<Name>
+#     Headers/                # public C API headers
+#     Resources/Info.plist    # minimal bundle metadata
+
+set -e -u
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <dylib> <framework_name> <output_dir> <headers_dir> [<short_version>] [<bundle_id>]" >&2
+  exit 2
+fi
+
+dylib="$1"
+framework_name="$2"
+output_dir="$3"
+headers_dir="$4"
+short_version="${5:-1.0}"
+bundle_id="${6:-org.kivy.${framework_name}}"
+
+if [ ! -f "$dylib" ]; then
+  echo "FATAL: input dylib not found: $dylib" >&2
+  exit 1
+fi
+if [ ! -d "$output_dir" ]; then
+  echo "FATAL: output directory does not exist: $output_dir" >&2
+  exit 1
+fi
+if [ ! -d "$headers_dir" ]; then
+  echo "FATAL: headers directory does not exist: $headers_dir" >&2
+  exit 1
+fi
+
+fw_root="$output_dir/$framework_name.framework"
+
+# Rebuild from scratch so stale contents from a previous run do not
+# sneak in (e.g. old Info.plist with a different version, or a header
+# that upstream ThorVG has since deleted).
+rm -rf "$fw_root"
+mkdir -p "$fw_root/Headers"
+mkdir -p "$fw_root/Resources"
+
+# 1. Install the binary. Using ``cp`` (not ``mv``) so the caller's
+#    ``dist/lib`` copy is preserved both for debugging and for the
+#    legacy dylib-probing fallback in ``setup.py::determine_thorvg_flags``
+#    (used by devs who point ``KIVY_THORVG_LIB_DIR`` directly at a
+#    raw Meson install).
+cp "$dylib" "$fw_root/$framework_name"
+chmod 644 "$fw_root/$framework_name"
+
+# 2. Rewrite ``LC_ID_DYLIB`` so dyld resolves the framework via
+#    ``@rpath/<Name>.framework/<Name>``. Without this, an extension
+#    that links against this framework would bake the original dylib
+#    path (e.g. ``kivy-dependencies/dist/lib/libthorvg-1.dylib``) into
+#    its ``LC_LOAD_DYLIB`` and break at import time once the wheel is
+#    installed anywhere else.
+install_name_tool -id \
+  "@rpath/$framework_name.framework/$framework_name" \
+  "$fw_root/$framework_name"
+
+# 3. Populate Headers/. ``cp -a`` preserves symlinks, which matters
+#    for some upstream include trees (not ThorVG today, but the helper
+#    wants to stay generic).
+cp -a "$headers_dir/." "$fw_root/Headers/"
+
+# 4. Minimal Info.plist. ``CFBundleExecutable`` must match the binary
+#    filename so Launch Services + dyld agree on what to load. On iOS
+#    the caller sets ``FRAMEWORK_MIN_OS_VERSION`` so App Store
+#    validation passes.
+min_os_entry=""
+if [ -n "${FRAMEWORK_MIN_OS_VERSION:-}" ]; then
+  min_os_entry="
+	<key>MinimumOSVersion</key>
+	<string>${FRAMEWORK_MIN_OS_VERSION}</string>"
+fi
+
+cat > "$fw_root/Resources/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${framework_name}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${bundle_id}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${framework_name}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${short_version}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${short_version}</string>${min_os_entry}
+</dict>
+</plist>
+PLIST
+
+echo "-- Wrapped $dylib -> $fw_root"
+otool -D "$fw_root/$framework_name" || true
+file "$fw_root/$framework_name" || true

--- a/tools/meson-cross-ios-device.ini
+++ b/tools/meson-cross-ios-device.ini
@@ -1,0 +1,32 @@
+# Meson cross-file for iOS device (arm64, iphoneos SDK)
+#
+# Deployment target: iOS 16.0  (matches ANGLE xcframework in the Kivy bundle)
+# Architecture:      arm64 only
+#
+# The SDK sysroot (-isysroot), -arch flag, and deployment target flag
+# (-mios-version-min=16.0) are NOT hardcoded here; they are injected at
+# build time by tools/build_thorvg.sh (THORVG_IOS=iphoneos branch) via
+# -Dc_args / -Dcpp_args / -Dc_link_args / -Dcpp_link_args on the meson
+# setup command line.  Cross-files are re-read on reconfigure, so keeping
+# runtime-variable values out of the file avoids stale-cache surprises.
+
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'ar'
+strip     = 'strip'
+# Disable pkg-config so Meson cannot accidentally resolve macOS host
+# libraries (e.g. Homebrew SDL3) while cross-compiling for iOS.
+pkgconfig = 'false'
+
+[properties]
+# iOS executables cannot run on the build machine.
+needs_exe_wrapper = true
+
+[host_machine]
+system     = 'darwin'
+subsystem  = 'ios'
+kernel     = 'xnu'
+cpu_family = 'aarch64'
+cpu        = 'arm64'
+endian     = 'little'

--- a/tools/meson-cross-ios-sim.ini
+++ b/tools/meson-cross-ios-sim.ini
@@ -1,0 +1,39 @@
+# Meson cross-file for iOS Simulator (universal arm64 + x86_64, iphonesimulator SDK)
+#
+# Deployment target: iOS 16.0 simulator  (matches ANGLE xcframework in the Kivy bundle)
+# Architecture:      universal arm64 + x86_64 (fat binary)
+#
+# The multi-arch fat binary is produced by passing BOTH -arch arm64 and
+# -arch x86_64 to Apple Clang via -Dc_args / -Dcpp_args in the meson setup
+# command.  Meson itself only understands a single cpu_family (aarch64 is
+# listed here as the primary); the second arch is handled transparently by
+# the compiler flag and is invisible to Meson's dependency resolver.
+#
+# The SDK sysroot (-isysroot), arch flags, and deployment target flag
+# (-mios-simulator-version-min=16.0) are injected at build time by
+# tools/build_thorvg.sh (THORVG_IOS=iphonesimulator branch).
+
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'ar'
+strip     = 'strip'
+# Disable pkg-config so Meson cannot accidentally resolve macOS host
+# libraries (e.g. Homebrew SDL3) while cross-compiling for the simulator.
+pkgconfig = 'false'
+
+[properties]
+# Simulator executables can technically run on the build machine, but
+# Meson does not know that; keeping this true prevents it from attempting
+# to execute build artefacts during the configure / test phase when the
+# binary may be a multi-arch fat file that the host linker can't load
+# without the simulator runtime.
+needs_exe_wrapper = true
+
+[host_machine]
+system     = 'darwin'
+subsystem  = 'ios'
+kernel     = 'xnu'
+cpu_family = 'aarch64'
+cpu        = 'arm64'
+endian     = 'little'


### PR DESCRIPTION
## Summary

Builds \`KivyThorVG.xcframework\` (arm64 device + universal arm64/x86_64 simulator, iOS 16.0) and wires it into Kivy's existing iOS wheel pipeline. No changes required to \`tools/add-ios-frameworks.py\` — it auto-discovers the new xcframework from \`dist/Frameworks/\`.

**Commits:**
- \`tools/meson-cross-ios-{device,sim}.ini\` — Meson cross-files for iphoneos / iphonesimulator (iOS 16.0, matches ANGLE xcframework minimum already in the bundle)
- \`tools/build_thorvg.sh\` — new \`THORVG_IOS=iphoneos|iphonesimulator\` mode; forces \`THORVG_SHARED=1\`; resolves SDK sysroot via \`xcrun\` at runtime
- \`tools/build_ios_dependencies.sh\` — per-slice Meson build → \`macos_framework_wrapper.sh\` → \`xcodebuild -create-xcframework\`; CI cache key auto-invalidates
- \`setup.py\` — adds \`KivyThorVG\` to \`plat_options['ios']['frameworks']\`; iOS early-return in \`determine_thorvg_flags()\` with \`-F\`/\`-framework KivyThorVG\`/\`@rpath\` flags mirroring SDL3; removes \`'ios'\` from \`TVG_STATIC\` static-platform list

## Verified locally (Intel Mac, Xcode 16, cibuildwheel 3.3.1, Python 3.13 iOS b12)

- \`lipo -info\` → arm64-only device dylib, universal arm64+x86_64 simulator dylib ✓
- \`LC_BUILD_VERSION minos 16.0\` on both slices ✓
- \`otool -L _thorvg.cpython-313-iphoneos.so\` → \`@rpath/KivyThorVG.framework/KivyThorVG\` ✓
- \`add-ios-frameworks.py\` packs \`.frameworks/KivyThorVG.xcframework/\` into the wheel automatically ✓
- xcframework slice dirs \`ios-arm64\` and \`ios-arm64_x86_64-simulator\` match \`plat_arch\` keys in \`setup.py\` ✓

## Depends on (merge first)

- #9297 \`feature/thorvg-cython\` — Cython wrapper + \`determine_thorvg_flags\` (Phase 1, must be on master before this merges)

cc @misl6 @psychowasp @T-Dynamos