### PR TITLE
Implement kivy.mobile Android backend (jnius)

### DIFF
--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -1,24 +1,23 @@
-"""Android placeholder for the kivy.mobile platform API.
+"""Android implementation of the kivy.mobile platform API.
 
-.. warning:: **This module is a placeholder — it has not been tested on Android.**
+Reads runtime window/display geometry from the running Android activity using
+``jnius`` (https://github.com/kivy/pyjnius) — a standalone Kivy-org package
+present in every Kivy Android build.  No compiled extension and no
+python-for-android module changes are required: every value is obtained by
+reflection against ``PythonActivity.mActivity`` and the Android framework.
 
-    The implementations for ``get_dpi()``, ``get_scale()``, and
-    ``get_keyboard_height()`` are straightforward — they use ``jnius``
-    (a standalone Kivy-org package: https://github.com/kivy/pyjnius) and
-    the ``android`` module provided by python-for-android, both of which
-    are already present in every Kivy Android build.
+All lengths are returned in **pixels**, which is Kivy's layout coordinate
+system on Android (``density`` is folded into :class:`kivy.metrics.Metrics`,
+not into window coordinates).
 
-    I would propose changes to p4a that would need to be acceped by the
-    p4a maintainers prior to completing this implementation.
+Window-insets and display-cutout reads must run on the Android UI thread —
+Kivy/SDL runs on a separate thread — so those calls are marshalled onto the UI
+thread via ``Activity.runOnUiThread`` and block briefly for the result.
+``DisplayMetrics`` is thread-safe to read directly.
 
-TODO (follow-up PR — post p4a changes, needs Android device or emulator to validate):
-    * get_dpi()               — jnius: Hardware.getDPI()
-    * get_scale()             — jnius: Hardware.metrics.scaledDensity
-    * get_keyboard_height()   — android module: android.get_keyboard_height()
-    * subscribe_keyboard_height() — drive from android keyboard events
-    * get_safe_area()         — WindowInsetsCompat system-gesture insets (API 29+)
-    * get_display_cutout()    — DisplayCutout bounding rects (API 28+)
-    * get_system_bar_insets() — status-bar / nav-bar insets separated
+Requires an API 30+ (Android 11+) device: ``WindowInsets.getInsets(type)`` and
+the ``ime()`` inset type were added in API 30.  Method resolution happens at
+runtime via reflection, so the build/compile API level is irrelevant.
 
 This module is imported automatically by ``kivy.mobile`` when
 ``kivy.utils.platform == 'android'``.  Do not import it directly.
@@ -26,66 +25,251 @@ This module is imported automatically by ``kivy.mobile`` when
 
 from __future__ import annotations
 
-import warnings
+import threading
 
-warnings.warn(
-    "kivy.mobile Android support is not yet implemented. "
-    "All kivy.mobile calls will return safe fallback values. "
-    "See kivy/mobile/_platform/android.py for details.",
-    UserWarning,
-    stacklevel=2,
-)
+from jnius import autoclass, PythonJavaClass, java_method
+
+PythonActivity = autoclass("org.kivy.android.PythonActivity")
+DisplayMetrics = autoclass("android.util.DisplayMetrics")
+WindowInsetsType = autoclass("android.view.WindowInsets$Type")
+
+# Strong references to Runnables until the UI thread has executed them.
+_runnable_refs: list = []
+
+
+def _activity():
+    return PythonActivity.mActivity
+
+
+class _Runnable(PythonJavaClass):
+    __javainterfaces__ = ["java/lang/Runnable"]
+    __javacontext__ = "app"
+
+    def __init__(self, func):
+        super().__init__()
+        self._func = func
+
+    @java_method("()V")
+    def run(self):
+        self._func()
+
+
+def _on_ui_thread(func, timeout: float = 2.0):
+    """Run *func* on the Android UI thread and return its result (blocking)."""
+    box: dict = {}
+    done = threading.Event()
+
+    def wrapper():
+        try:
+            box["value"] = func()
+        except Exception as exc:  # noqa: BLE001
+            box["error"] = exc
+        finally:
+            done.set()
+
+    runnable = _Runnable(wrapper)
+    _runnable_refs.append(runnable)
+    try:
+        _activity().runOnUiThread(runnable)
+        if not done.wait(timeout=timeout):
+            raise TimeoutError("kivy.mobile: UI-thread geometry read timed out")
+        if "error" in box:
+            raise box["error"]
+        return box.get("value")
+    finally:
+        try:
+            _runnable_refs.remove(runnable)
+        except ValueError:
+            pass
+
+
+def _metrics():
+    metrics = DisplayMetrics()
+    _activity().getWindowManager().getDefaultDisplay().getMetrics(metrics)
+    return metrics
+
+
+def _root_insets():
+    """WindowInsets for the decor view (call only on the UI thread)."""
+    return _activity().getWindow().getDecorView().getRootWindowInsets()
+
 
 # ---------------------------------------------------------------------------
-# Tier-1 API — safe fallbacks (mirrors generic.py until implemented)
+# Tier-1 API
 # ---------------------------------------------------------------------------
 
 
 def get_dpi() -> float:
-    """Placeholder — returns 96.0 until Android support is implemented."""
-    return 96.0
+    """Physical screen DPI (Android ``densityDpi``; matches ``Metrics.dpi``)."""
+    try:
+        return float(_metrics().densityDpi)
+    except Exception:
+        return 96.0
 
 
 def get_scale() -> float:
-    """Placeholder — returns 1.0 until Android support is implemented."""
-    return 1.0
+    """Display scale factor (Android ``scaledDensity``)."""
+    try:
+        return float(_metrics().scaledDensity)
+    except Exception:
+        return 1.0
 
 
 def get_density() -> float:
-    """Alias for get_scale()."""
+    """Logical pixel density.  Alias for :func:`get_scale`."""
     return get_scale()
 
 
 def get_keyboard_height() -> float:
-    """Placeholder — returns 0.0 until Android support is implemented.
+    """Current soft-keyboard (IME) height in pixels; 0 when hidden."""
 
-    TODO: implement using android.get_keyboard_height() (p4a module) with
-    the USE_SDL3 guard from the legacy _get_android_kheight() in
-    kivy/core/window/__init__.py, then remove that method.
-    """
-    return 0.0
+    def work():
+        insets = _root_insets()
+        if insets is None:
+            return 0.0
+        return float(insets.getInsets(WindowInsetsType.ime()).bottom)
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return 0.0
 
 
 def get_safe_area() -> dict[str, float]:
-    """Placeholder — returns all-zero insets until Android support is implemented."""
-    return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
+    """Safe-area insets in pixels (system bars unioned with the display cutout).
 
+    Returns ``{"top", "left", "bottom", "right"}``.
+    """
 
-def subscribe_keyboard_height(callback) -> None:
-    """Placeholder — no-op until Android support is implemented."""
-    pass
+    def work():
+        insets = _root_insets()
+        if insets is None:
+            return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
+        bars = insets.getInsets(WindowInsetsType.systemBars())
+        cut = insets.getInsets(WindowInsetsType.displayCutout())
+        return {
+            "top": float(max(bars.top, cut.top)),
+            "left": float(max(bars.left, cut.left)),
+            "bottom": float(max(bars.bottom, cut.bottom)),
+            "right": float(max(bars.right, cut.right)),
+        }
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
 
 
 # ---------------------------------------------------------------------------
-# Tier-2 API — Android extras (not yet implemented)
+# Keyboard-height subscription
+#
+# Driven by polling the IME inset from a Kivy Clock tick, scheduled lazily on
+# the first subscription.  Subscribers are notified only when the height
+# changes (including back to 0 on hide).
+# ---------------------------------------------------------------------------
+
+_kb_subscribers: list = []
+_kb_last: float = 0.0
+_kb_poll_scheduled: bool = False
+
+
+def _poll_keyboard(_dt) -> None:
+    global _kb_last
+    height = get_keyboard_height()
+    if height != _kb_last:
+        _kb_last = height
+        for cb in list(_kb_subscribers):
+            try:
+                cb(height)
+            except Exception:
+                pass
+
+
+def subscribe_keyboard_height(callback) -> None:
+    """Register *callback(height: float)* for keyboard-height changes.
+
+    The callback runs on the Kivy main thread, so it is safe to update Kivy
+    properties directly.  It is invoked with 0.0 when the keyboard hides.
+    """
+    global _kb_poll_scheduled
+    _kb_subscribers.append(callback)
+    if not _kb_poll_scheduled:
+        from kivy.clock import Clock
+
+        Clock.schedule_interval(_poll_keyboard, 1 / 10.0)
+        _kb_poll_scheduled = True
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 API — Android extras
 # ---------------------------------------------------------------------------
 
 
 def get_display_cutout():
-    """Placeholder — returns None until Android support is implemented."""
-    return None
+    """Physical display-cutout regions, or ``None`` when the window has none.
+
+    Returns a list of ``{"left", "top", "right", "bottom"}`` pixel rects (one
+    per cutout).  Returns ``None`` when the current window does not overlap any
+    cutout (e.g. when Android letterboxes the app away from it in landscape
+    under the default cutout mode).
+    """
+
+    def work():
+        insets = _root_insets()
+        if insets is None:
+            return None
+        cutout = insets.getDisplayCutout()
+        if cutout is None:
+            return None
+        rects = cutout.getBoundingRects()
+        out = []
+        for i in range(rects.size()):
+            r = rects.get(i)
+            out.append(
+                {
+                    "left": int(r.left),
+                    "top": int(r.top),
+                    "right": int(r.right),
+                    "bottom": int(r.bottom),
+                }
+            )
+        return out or None
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return None
 
 
 def get_system_bar_insets():
-    """Placeholder — returns None until Android support is implemented."""
-    return None
+    """Status-bar and navigation-bar insets separated, in pixels, or ``None``.
+
+    Returns ``{"status_bar": {...}, "nav_bar": {...}}`` where each value is a
+    ``{"left", "top", "right", "bottom"}`` dict.
+    """
+
+    def work():
+        insets = _root_insets()
+        if insets is None:
+            return None
+        status = insets.getInsets(WindowInsetsType.statusBars())
+        nav = insets.getInsets(WindowInsetsType.navigationBars())
+        return {
+            "status_bar": {
+                "top": int(status.top),
+                "left": int(status.left),
+                "bottom": int(status.bottom),
+                "right": int(status.right),
+            },
+            "nav_bar": {
+                "top": int(nav.top),
+                "left": int(nav.left),
+                "bottom": int(nav.bottom),
+                "right": int(nav.right),
+            },
+        }
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary

Implements the Android backend for `kivy.mobile` — the platform-neutral mobile
window/display geometry API introduced in #9331 — replacing the placeholder in
`kivy/mobile/_platform/android.py`.

All values are read at runtime by reflecting against the running
`PythonActivity.mActivity` via `jnius` (a standalone Kivy-org package present in
every Kivy Android build). **No compiled extension and no python-for-android
changes are required.**

### Implemented

Tier-1 (cross-platform API):
- `get_dpi()` — physical screen DPI (`densityDpi`); matches `Metrics.dpi`
- `get_scale()` / `get_density()` — display scale factor (`scaledDensity`)
- `get_keyboard_height()` — soft-keyboard (IME) height in px, 0 when hidden
- `get_safe_area()` — system-bar insets unioned with the display cutout
- `subscribe_keyboard_height(callback)` — keyboard-height change notifications,
  driven by a lazily-scheduled Kivy `Clock` poll (callback runs on the Kivy main
  thread, so it can update Kivy properties directly)

Tier-2 (Android extras):
- `get_display_cutout()` — cutout bounding rects, or `None`
- `get_system_bar_insets()` — status-bar and nav-bar insets, separated

### Implementation notes

- Lengths are returned in **pixels** (Kivy's Android layout coordinate system;
  density is folded into `kivy.metrics.Metrics`, not window coordinates).
- `WindowInsets` / `DisplayCutout` reads are marshalled onto the Android UI
  thread via `Activity.runOnUiThread` (Kivy/SDL runs on a separate thread);
  `DisplayMetrics` is read directly since it is thread-safe.
- Requires an **API 30+** device (`WindowInsets.getInsets(type)` and the `ime()`
  inset type were added in API 30). Method resolution is via reflection, so the
  build/compile API level is irrelevant.
- All getters degrade gracefully (fallback values / `None`) on error.

## Test plan / validation

Validated on a physical **Pixel 8a** using a Kivy probe app that displayed each
API's live value and cross-checked it against `kivy.metrics.Metrics`:

- `get_dpi()` / `get_scale()` / `get_density()` match `Metrics`.
- `get_keyboard_height()` reports correctly (0 hidden, non-zero shown), and
  `subscribe_keyboard_height` fires on show/hide.
- `get_safe_area()`, `get_display_cutout()`, and `get_system_bar_insets()`
  validated in both portrait and landscape.

The logic was first validated via a byte-identical standalone prototype on the
device, then transplanted here. An integration build (this branch compiled into
an APK with python-for-android + SDL3) confirmed Kivy 3.0 packages `kivy.mobile`
correctly and imports the backend. A full live-GUI retest will follow once
kivyforge's Android backend is in place.
