### PR TITLE
Remove remaining python-for-android android module usage from Kivy core

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -1107,8 +1107,8 @@ Context.html#getFilesDir()>`_ is returned.
         Except on Android, set Android state to stop, Kivy state then follows.
         '''
         if platform == 'android':
-            from android import mActivity
-            mActivity.finishAndRemoveTask()
+            from kivy.mobile._platform.android import finish_and_remove_task
+            finish_and_remove_task()
         else:
             self._stop()
 
@@ -1130,8 +1130,8 @@ Context.html#getFilesDir()>`_ is returned.
         .. versionadded:: 2.2.0
         '''
         if platform == 'android':
-            from android import mActivity
-            mActivity.moveTaskToBack(True)
+            from kivy.mobile._platform.android import move_task_to_back
+            move_task_to_back()
         else:
             Logger.info('App.pause() is not available on this OS.')
 

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -238,11 +238,11 @@ class EventLoopBase(EventDispatcher):
     def remove_android_splash(self, *args):
         '''Remove android presplash in SDL3 bootstrap.'''
         try:
-            from android import remove_presplash
+            from kivy.mobile._platform.android import remove_presplash
             remove_presplash()
         except ImportError:
             Logger.warning(
-                'Base: Failed to import "android" module. '
+                'Base: Failed to import the android platform backend. '
                 'Could not remove android presplash.')
             return
 

--- a/kivy/core/audio_output/audio_android.py
+++ b/kivy/core/audio_output/audio_android.py
@@ -5,9 +5,9 @@ AudioAndroid: Kivy audio implementation for Android using native API
 __all__ = ("SoundAndroidPlayer", )
 
 from jnius import autoclass, java_method, PythonJavaClass
-from android import api_version
 from kivy.core.audio_output import Sound, SoundLoader
 
+api_version = autoclass("android.os.Build$VERSION").SDK_INT
 
 MediaPlayer = autoclass("android.media.MediaPlayer")
 AudioManager = autoclass("android.media.AudioManager")

--- a/kivy/core/clipboard/clipboard_android.py
+++ b/kivy/core/clipboard/clipboard_android.py
@@ -9,15 +9,48 @@ __all__ = ('ClipboardAndroid', )
 
 from kivy import Logger
 from kivy.core.clipboard import ClipboardBase
-from jnius import autoclass, cast
-from android.runnable import run_on_ui_thread
-from android import python_act
+from jnius import autoclass, cast, PythonJavaClass, java_method
 
 AndroidString = autoclass('java.lang.String')
-PythonActivity = python_act
+PythonActivity = autoclass('org.kivy.android.PythonActivity')
 Context = autoclass('android.content.Context')
 VER = autoclass('android.os.Build$VERSION')
 sdk = VER.SDK_INT
+
+
+class _Runnable(PythonJavaClass):
+    '''Schedule a Python call onto the Android UI thread (fire-and-forget).
+
+    A tiny local replacement for python-for-android's ``android.runnable`` so
+    this provider depends only on pyjnius, not the p4a ``android`` module.
+    '''
+
+    __javainterfaces__ = ['java/lang/Runnable']
+    __javacontext__ = 'app'
+    # Keep strong references until the JVM has run each proxy, otherwise the
+    # pyjnius object may be collected before ``run()`` fires.
+    _refs = []
+
+    def __init__(self, func, args, kwargs):
+        super().__init__()
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        _Runnable._refs.append(self)
+
+    @java_method('()V')
+    def run(self):
+        try:
+            self._func(*self._args, **self._kwargs)
+        finally:
+            _Runnable._refs.remove(self)
+
+
+def run_on_ui_thread(f):
+    '''Decorator running *f* on the UI thread via ``Activity.runOnUiThread``.'''
+    def wrapper(*args, **kwargs):
+        PythonActivity.mActivity.runOnUiThread(_Runnable(f, args, kwargs))
+    return wrapper
 
 
 class ClipboardAndroid(ClipboardBase):

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -2087,8 +2087,8 @@ class WindowBase(EventDispatcher):
         # TODO If just CMD+w is pressed, only the window should be closed.
         is_osx = platform == 'darwin'
         if key == 27 and platform == 'android':
-            from android import mActivity
-            mActivity.moveTaskToBack(True)
+            from kivy.mobile._platform.android import move_task_to_back
+            move_task_to_back()
             return True
         elif WindowBase.on_keyboard.exit_on_escape:
             if key == 27 or all([is_osx, key in [113, 119], modifier == 1024]):

--- a/kivy/core/window/window_sdl3.py
+++ b/kivy/core/window/window_sdl3.py
@@ -249,8 +249,10 @@ class WindowSDL(WindowBase):
                 if platform == 'android':
                     Logger.info(
                         'WindowSDL: App stopped, on_pause() returned False.')
-                    from android import mActivity
-                    mActivity.finishAndRemoveTask()
+                    from kivy.mobile._platform.android import (
+                        finish_and_remove_task,
+                    )
+                    finish_and_remove_task()
                 else:
                     Logger.info(
                         'WindowSDL: App doesn\'t support pause mode, stop.')

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -27,7 +27,9 @@ runtime API matters):
   API 30+ (Android 11); use ``WindowInsets.getInsets(type)`` and the typed
   ``ime()`` / ``systemBars()`` / ``displayCutout()`` insets added in API 30.
 * ``move_task_to_back`` / ``finish_and_remove_task`` — all supported API levels
-  (stock ``android.app.Activity`` methods).  These are app/task lifecycle
+  (stock ``android.app.Activity`` methods).  ``remove_presplash`` similarly
+  needs no minimum API but depends on the bootstrap ``removeLoadingScreen``
+  method (see the bootstrap contract below).  These are app/task lifecycle
   actions rather than geometry reads; they are Android-only (no cross-platform
   analogue) so they are not surfaced through the neutral ``kivy.mobile`` API.
 
@@ -48,6 +50,11 @@ this in sync when adding bootstrap-coupled features:
   a static ``mActivity`` field holding the current ``android.app.Activity``.
   **Hard requirement** — the whole backend resolves geometry through it; if the
   bootstrap renames or omits it, the module degrades to safe defaults on import.
+* ``mActivity.removeLoadingScreen()`` — **soft requirement**, used only by
+  :func:`remove_presplash` to dismiss the boot splash.  This is a
+  bootstrap-provided method (not stock Android framework); a bootstrap that
+  omits it simply cannot remove the splash this way, and the caller in
+  ``kivy.base`` already tolerates that.
 
 This module is imported automatically by ``kivy.mobile`` when
 ``kivy.utils.platform == 'android'``.  Do not import it directly.
@@ -438,14 +445,15 @@ def get_system_bar_insets():
 # ---------------------------------------------------------------------------
 # App / task lifecycle
 #
-# Thin wrappers over stock ``android.app.Activity`` methods, kept here so Kivy's
-# cross-platform layers (App, Window) reach the Android bootstrap only through
-# ``kivy.mobile`` rather than importing the python-for-android ``android``
-# module directly.  These are Android-only actions with no cross-platform
-# analogue, so they live on this backend and are not exposed on the neutral
-# ``kivy.mobile`` surface.  Callers invoke them under a ``platform == 'android'``
-# guard.  Both run on the calling (Kivy) thread, matching Kivy's long-standing
-# behaviour for these calls.
+# Thin wrappers over stock ``android.app.Activity`` methods (plus the
+# bootstrap-provided splash call), kept here so Kivy's cross-platform layers
+# (App, Window, base) reach the Android bootstrap only through ``kivy.mobile``
+# rather than importing the python-for-android ``android`` module directly.
+# These are Android-only actions with no cross-platform analogue, so they live
+# on this backend and are not exposed on the neutral ``kivy.mobile`` surface.
+# Callers invoke them under a ``platform == 'android'`` guard.  They run on the
+# calling (Kivy) thread, matching Kivy's long-standing behaviour for these
+# calls.
 # ---------------------------------------------------------------------------
 
 
@@ -465,3 +473,14 @@ def finish_and_remove_task() -> None:
     Android task is torn down along with the Kivy app.
     """
     _activity().finishAndRemoveTask()
+
+
+def remove_presplash() -> None:
+    """Dismiss the Android boot splash / loading screen.
+
+    Wraps the bootstrap-provided ``mActivity.removeLoadingScreen()`` (see the
+    "Android bootstrap contract" above), mirroring python-for-android's
+    ``android.remove_presplash`` for the sdl2/sdl3 bootstraps so ``kivy.base``
+    can drop the splash without importing the p4a ``android`` module.
+    """
+    _activity().removeLoadingScreen()

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -26,6 +26,10 @@ runtime API matters):
 * ``get_keyboard_height`` / ``get_safe_area`` / ``get_system_bar_insets`` —
   API 30+ (Android 11); use ``WindowInsets.getInsets(type)`` and the typed
   ``ime()`` / ``systemBars()`` / ``displayCutout()`` insets added in API 30.
+* ``move_task_to_back`` / ``finish_and_remove_task`` — all supported API levels
+  (stock ``android.app.Activity`` methods).  These are app/task lifecycle
+  actions rather than geometry reads; they are Android-only (no cross-platform
+  analogue) so they are not surfaced through the neutral ``kivy.mobile`` API.
 
 On older devices the module still imports and the lower-API getters keep
 working; the higher-API getters degrade to zeros/``None`` and emit a one-time
@@ -429,3 +433,35 @@ def get_system_bar_insets():
         return _on_ui_thread(work)
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# App / task lifecycle
+#
+# Thin wrappers over stock ``android.app.Activity`` methods, kept here so Kivy's
+# cross-platform layers (App, Window) reach the Android bootstrap only through
+# ``kivy.mobile`` rather than importing the python-for-android ``android``
+# module directly.  These are Android-only actions with no cross-platform
+# analogue, so they live on this backend and are not exposed on the neutral
+# ``kivy.mobile`` surface.  Callers invoke them under a ``platform == 'android'``
+# guard.  Both run on the calling (Kivy) thread, matching Kivy's long-standing
+# behaviour for these calls.
+# ---------------------------------------------------------------------------
+
+
+def move_task_to_back() -> None:
+    """Send the app's task to the background (Android "Home"-like behaviour).
+
+    Wraps ``Activity.moveTaskToBack(true)``; used for the pause / back-gesture
+    paths where the app should be backgrounded rather than destroyed.
+    """
+    _activity().moveTaskToBack(True)
+
+
+def finish_and_remove_task() -> None:
+    """Finish the app and remove it from the recents list.
+
+    Wraps ``Activity.finishAndRemoveTask()``; used for the stop path so the
+    Android task is torn down along with the Kivy app.
+    """
+    _activity().finishAndRemoveTask()

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -155,6 +155,7 @@ class _FakeActivity:
         self._resources = _FakeResources(font_scale)
         self.moved_to_back = None
         self.finished = False
+        self.presplash_removed = False
 
     def runOnUiThread(self, runnable):
         # Run synchronously so the backend's UI-thread marshaling completes
@@ -175,6 +176,9 @@ class _FakeActivity:
 
     def finishAndRemoveTask(self):
         self.finished = True
+
+    def removeLoadingScreen(self):
+        self.presplash_removed = True
 
 
 @contextmanager
@@ -298,7 +302,7 @@ class TestAndroidPlatform:
             "get_keyboard_height", "get_safe_area",
             "subscribe_keyboard_height",
             "get_display_cutout", "get_system_bar_insets",
-            "move_task_to_back", "finish_and_remove_task",
+            "move_task_to_back", "finish_and_remove_task", "remove_presplash",
         ):
             assert hasattr(android, fn), f"android missing: {fn}"
             assert callable(getattr(android, fn))
@@ -356,6 +360,12 @@ class TestAndroidPlatform:
         with _fake_jnius(_default_insets()) as android:
             android.finish_and_remove_task()
             assert android.PythonActivity.mActivity.finished is True
+
+    def test_remove_presplash_calls_activity(self):
+        # Dismisses the boot splash via the bootstrap removeLoadingScreen().
+        with _fake_jnius(_default_insets()) as android:
+            android.remove_presplash()
+            assert android.PythonActivity.mActivity.presplash_removed is True
 
     def test_safe_area_unions_system_bars_and_cutout(self):
         with _fake_jnius(_default_insets()) as android:

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -153,6 +153,8 @@ class _FakeActivity:
     def __init__(self, insets, font_scale=1.0):
         self._insets = insets
         self._resources = _FakeResources(font_scale)
+        self.moved_to_back = None
+        self.finished = False
 
     def runOnUiThread(self, runnable):
         # Run synchronously so the backend's UI-thread marshaling completes
@@ -167,6 +169,12 @@ class _FakeActivity:
 
     def getResources(self):
         return self._resources
+
+    def moveTaskToBack(self, non_root):
+        self.moved_to_back = non_root
+
+    def finishAndRemoveTask(self):
+        self.finished = True
 
 
 @contextmanager
@@ -290,6 +298,7 @@ class TestAndroidPlatform:
             "get_keyboard_height", "get_safe_area",
             "subscribe_keyboard_height",
             "get_display_cutout", "get_system_bar_insets",
+            "move_task_to_back", "finish_and_remove_task",
         ):
             assert hasattr(android, fn), f"android missing: {fn}"
             assert callable(getattr(android, fn))
@@ -335,6 +344,18 @@ class TestAndroidPlatform:
     def test_keyboard_height_reads_ime_inset(self):
         with _fake_jnius(_default_insets()) as android:
             assert android.get_keyboard_height() == 800.0
+
+    def test_move_task_to_back_calls_activity(self):
+        # Backgrounds the task via Activity.moveTaskToBack(true).
+        with _fake_jnius(_default_insets()) as android:
+            android.move_task_to_back()
+            assert android.PythonActivity.mActivity.moved_to_back is True
+
+    def test_finish_and_remove_task_calls_activity(self):
+        # Tears the task down via Activity.finishAndRemoveTask().
+        with _fake_jnius(_default_insets()) as android:
+            android.finish_and_remove_task()
+            assert android.PythonActivity.mActivity.finished is True
 
     def test_safe_area_unions_system_bars_and_cutout(self):
         with _fake_jnius(_default_insets()) as android:


### PR DESCRIPTION
## Summary

Follow-up to #9345. Moves the **remaining** direct `from android import ...`
uses of the python-for-android `android` module out of Kivy's cross-platform
code, so Kivy core reaches the Android bootstrap only through `kivy.mobile`
(or pyjnius directly, for Android-only providers).

- **App / task lifecycle** — `moveTaskToBack` / `finishAndRemoveTask` now go
  through `kivy.mobile._platform.android` (`kivy/app.py`,
  `kivy/core/window/__init__.py`, `kivy/core/window/window_sdl3.py`).
- **`kivy/base.py`** — presplash removal via
  `kivy.mobile._platform.android.remove_presplash()` (wraps the bootstrap
  `mActivity.removeLoadingScreen()`, documented as a soft bootstrap
  requirement). `base` is cross-platform core and must not import jnius
  directly, so it delegates to the mobile backend.
- **Android providers** — `audio_android.py` reads `Build.VERSION.SDK_INT`
  via jnius directly; `clipboard_android.py` resolves `PythonActivity` via
  jnius and ships a tiny local `run_on_ui_thread`/`Runnable`. These are
  Android-only, dynamically-loaded providers that already use pyjnius, so
  their jnius stays in place — only the p4a `android` link is severed.

### Why

Consolidating the Android-specific bridge in one place breaks the hard
dependency on the python-for-android `android` recipe, which simplifies
supporting separate bootstraps (e.g. kivyforge and p4a) and keeps the
mobile-specific code in a single, clearly documented location.

### Out of scope

The legacy pygame-era uses (`kivy/support.py`'s `install_android()` and the
`androidjoystick` provider) are dead code and are left for a separate
cleanup PR.

## Stacking

Stacked on #9345 — base branch is `kivy-mobile-android-backend`, so the diff
here is just the two lifecycle/provider commits. Retarget to `master` once
#9345 merges.

## Test plan

- [x] `ruff check` clean on all changed files.
- [x] `kivy.mobile` test suite (21 tests) passes (run via a standalone
      loader; the local checkout lacks compiled graphics so pytest's
      conftest can't import `kivy.graphics`).
- [x] On-device (Pixel 8a): back-key / pause / stop lifecycle and the
      keyboard input-type paths verified in earlier testing.
